### PR TITLE
Makes Login & Create User Pages Responsive

### DIFF
--- a/src/components/CreateUser.js
+++ b/src/components/CreateUser.js
@@ -23,23 +23,6 @@ class CreateUser extends React.Component {
     };
   }
 
-  renderModal = () => {
-    return (
-      <div className="login-page-content">
-        <div style={{ height: "0px" }}>&nbsp;</div>
-        {/*for some reason when you don't have a non empty element above the modal,
-        it leaves a white section above it...so thats why this is here*/}
-        <div className="login-modal">
-          <CreateUserModal />
-        </div>
-      </div>
-    );
-  };
-
-  renderFooter = () => {
-    return <Footer />;
-  };
-
   render() {
     //if we haven't checked if the user is logged in yet, show a loading screen
     return (
@@ -48,9 +31,11 @@ class CreateUser extends React.Component {
           <div style={{ height: "0px" }}>&nbsp;</div>
           {/*for some reason when you don't have a non empty element above the modal,
           it leaves a white section above it...so thats why this is here*/}
-          {this.renderModal()}
+          <div className="login-modal">
+            <CreateUserModal />
+          </div>
         </div>
-        {this.renderFooter()}
+        <Footer />
       </div>
     );
   }

--- a/src/components/CreateUser/CreateUserModal.js
+++ b/src/components/CreateUser/CreateUserModal.js
@@ -157,7 +157,7 @@ export default class CreateUserModal extends React.Component {
     </div>
   );
 
-  renderHeader = () => <div className="login-header">Create a new Account</div>;
+  renderHeader = () => <div className="login-header">Create a new account</div>;
 
   renderLoader = () => (
     <div className="login-form-loader">
@@ -173,7 +173,7 @@ export default class CreateUserModal extends React.Component {
 
   renderLink = () => (
     <Link to="/login" className="login-form-link">
-      Already have an account? Click here to login
+      Already have an account? Click here to login.
     </Link>
   );
 

--- a/src/components/CreateUser/CreateUserModal.js
+++ b/src/components/CreateUser/CreateUserModal.js
@@ -166,7 +166,7 @@ export default class CreateUserModal extends React.Component {
   );
 
   renderButton = () => (
-    <button className="login-form-button" style={{ width: "37.5%" }} type="submit">
+    <button className="login-form-button" type="submit">
       Create Account
     </button>
   );
@@ -185,6 +185,7 @@ export default class CreateUserModal extends React.Component {
         {this.renderInputs()}
         {this.renderButton()}
         {this.renderLoader()}
+        <br />
         {this.renderLink()}
       </form>
     );

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -22,8 +22,13 @@ class Login extends React.Component {
         <div style={{ height: "0px" }}>&nbsp;</div>
         {/*for some reason when you don't have a non empty element above the modal,
         it leaves a white section above it...so thats why this is here*/}
-        <div className="login-modal">
-          <LoginModal provider={this.props.provider} />
+        <div className="row">
+          <div className="col">
+            <div className="login-modal">
+              <LoginModal provider={this.props.provider} />
+            </div>
+          </div>
+          <div className="col hidden-small" />
         </div>
       </div>
     );

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -22,13 +22,8 @@ class Login extends React.Component {
         <div style={{ height: "0px" }}>&nbsp;</div>
         {/*for some reason when you don't have a non empty element above the modal,
         it leaves a white section above it...so thats why this is here*/}
-        <div className="row">
-          <div className="col">
-            <div className="login-modal">
-              <LoginModal provider={this.props.provider} />
-            </div>
-          </div>
-          <div className="col hidden-small" />
+        <div className="login-modal">
+          <LoginModal provider={this.props.provider} />
         </div>
       </div>
     );

--- a/src/components/Login/LoginModal.js
+++ b/src/components/Login/LoginModal.js
@@ -111,7 +111,9 @@ export default class LoginModal extends React.Component {
     return (
       <form className="login-form" onSubmit={this.handleEmailLogin}>
         {/*Form doesn't do anything rn, just an example of a stateful React form.*/}
-        <div className="login-header">{"Welcome to <Teach LA>"}</div>
+        <div className="login-header">
+          Welcome to <span className="force-no-wrap">&lt;Teach LA&gt;</span>
+        </div>
         <br />
         {this.renderInputs()}
         <div className="login-form-loader">

--- a/src/components/Login/LoginModal.js
+++ b/src/components/Login/LoginModal.js
@@ -121,7 +121,7 @@ export default class LoginModal extends React.Component {
           <button className="login-form-button" type="submit">
             Login
           </button>
-          {/*imgSrc is relative to the public folder if you put a path, hence why theres no img folder in src */}
+          {/*
           <SocialButton
             imgSrc="img/fbLogo1.png"
             bgColor="#4267b2"
@@ -129,6 +129,7 @@ export default class LoginModal extends React.Component {
             value="Login with Facebook"
             handleLogin={this.handleSocialLogin}
           />
+          */}
         </div>
         <br />
         <Link to="/createUser" className="login-form-link">

--- a/src/components/Login/LoginModal.js
+++ b/src/components/Login/LoginModal.js
@@ -3,7 +3,7 @@ import SHA256 from "crypto-js/sha256";
 import { RingLoader } from "react-spinners";
 import { EMAIL_DOMAIN_NAME } from "../../constants";
 import { Link } from "react-router-dom";
-import SocialButton from "../common/SocialButton";
+//import SocialButton from "../common/SocialButton";
 import LoginInput from "./LoginInput";
 import firebase from "firebase";
 import "../../styles/Login.css";

--- a/src/components/Login/LoginModal.js
+++ b/src/components/Login/LoginModal.js
@@ -117,23 +117,22 @@ export default class LoginModal extends React.Component {
         <div className="login-form-loader">
           <RingLoader color={"#857e8f"} size={50} loading={this.state.waiting} />
         </div>
-        <button className="login-form-button" type="submit">
-          Login
-        </button>
-        <div className="login-button-list">
+        <div>
+          <button className="login-form-button" type="submit">
+            Login
+          </button>
           {/*imgSrc is relative to the public folder if you put a path, hence why theres no img folder in src */}
-          {/*textPadding's value is kinda arbitrary, it's kind of a fiddling game*/}
           <SocialButton
             imgSrc="img/fbLogo1.png"
             bgColor="#4267b2"
             textColor="white"
-            textPadding="15px"
             value="Login with Facebook"
             handleLogin={this.handleSocialLogin}
           />
         </div>
+        <br />
         <Link to="/createUser" className="login-form-link">
-          Don't have an account? Click here to create a new account
+          Don't have an account? Create one now!
         </Link>
       </form>
     );

--- a/src/components/common/SocialButton.js
+++ b/src/components/common/SocialButton.js
@@ -16,22 +16,16 @@ const SocialButton = props => (
     onClick={props.handleLogin}
   >
     {/*Style in React is different than css, you give it a JSON with camelcased keys of css like background-color is backgroundColor*/}
-    <div style={{ position: "relative" }}>
-      <span className="login-button-content">
-        {props.imgSrc ? (
-          <img className="login-button-img" alt="Login" src={props.imgSrc} />
-        ) : (
-          <span />
-        )}
-        <span
-          className="login-button-text"
-          style={{ left: props.textPadding ? props.textPadding : "0px" }}
-        >
-          {props.children ? props.children : props.value ? props.value : "Login"}
-          {/*if there's children, render the children, otherwise if value is defined, render value, otherwise just render "Login"*/}
-        </span>
-      </span>
-    </div>
+
+    <span className="login-button-content">
+      {props.imgSrc ? (
+        <img className="login-button-img" alt="Login" src={props.imgSrc} />
+      ) : (
+        <span />
+      )}
+      {props.children ? props.children : props.value ? props.value : "Login"}
+      {/*if there's children, render the children, otherwise if value is defined, render value, otherwise just render "Login"*/}
+    </span>
   </button>
 );
 

--- a/src/styles/Login.css
+++ b/src/styles/Login.css
@@ -1,18 +1,56 @@
 .login-page {
   margin: 0px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .login-page-content {
+  width: 100%;
   height: 100vh;
-  background-color: #272134;
   background-image: url("../img/blueguy-transparent-2.png");
   background-repeat: no-repeat;
   background-position: right top;
   background-size: auto 93%;
-  min-height: 600px;
   overflow-y: auto;
   box-sizing: border-box;
+  background-color: #272134;
   padding-bottom: 8vh;
+}
+
+@media only screen and (max-width: 1000px) {
+  .hidden-small {
+    display: none;
+  }
+  .login-page-content {
+    background-image: none;
+  }
+}
+
+.row {
+  position: relative;
+  width: 100%;
+}
+
+.row [class^="col"] {
+  float: left;
+  min-height: 0.125rem;
+}
+
+.row::after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+.col {
+  width: 50%;
+}
+
+@media only screen and (max-width: 1000px) {
+  .col {
+    width: 100%;
+  }
 }
 
 .login-footer {
@@ -31,7 +69,7 @@
 }
 
 .login-form {
-  padding: 20px 20px;
+  padding: 0 1.5em;
   color: #dddcdf;
 }
 
@@ -44,8 +82,7 @@
 }
 
 .login-header {
-  font-size: 48px;
-  white-space: nowrap;
+  font-size: 40px;
   font-weight: bold;
 }
 
@@ -55,30 +92,22 @@
   margin-bottom: 1rem;
 }
 
-.login-form-input-list {
-  padding-left: 40px;
-}
-
 .login-form-input-error {
   color: red;
   font-size: 1rem;
 }
 
-.login-button-list {
-  width: 100%;
-  padding: 0 15%;
-}
-
 .login-modal {
   font-family: "Josefin Slab", sans-serif; /*font for the whole login page*/
   display: block;
-  width: 460px;
-  min-width: 469px;
-  min-height: 550px;
   margin-top: 30px; /*modal distance from top of the screen*/
-  margin-left: 8%; /*modal distance from left side of the screen*/
-  padding: 15px;
   box-sizing: border-box;
+}
+
+@media only screen and (max-width: 1000px) {
+  .login-modal {
+    text-align: center;
+  }
 }
 
 .login-form-input {
@@ -95,8 +124,9 @@
   -moz-appearance: none;
   appearance: none;
   outline: 0;
-  width: 70%;
+  width: 50%;
   min-width: 300px;
+  max-width: 500px;
   margin: 0 2px 1rem; /*last value controls how far the next input starts*/
   font-variant-ligatures: none;
   -webkit-transition: box-shadow 70ms ease-out, border-color 70ms ease-out;
@@ -118,14 +148,21 @@
 }
 
 .login-form-button {
-  border: 0px;
+  display: inline-block;
   font-family: "Josefin Slab", sans-serif;
-  font-size: 1.3rem;
   color: #dddcdf;
-  margin: 20px 32.5% 10px; /*margin leftright is half of 100% - width*/
-  width: 35%;
   background-color: #857e8f;
-  height: 40px;
+  cursor: pointer;
+  overflow: visible;
+  text-align: center;
+  border: 0;
+  border-radius: 3px;
+  user-select: none;
+  text-decoration: none;
+  padding: 0.5em 1em;
+  font-size: 1.3rem;
+  line-height: 1.4em;
+  margin-right: 0.5em;
 }
 
 .login-form-link {
@@ -137,27 +174,4 @@
 .login-form-link:hover {
   color: #2d7799;
   text-decoration: underline;
-}
-
-.razor {
-  /* position:"relative"; */
-  /* width:100%; */
-  height: 800px;
-  background: #00ff00;
-}
-
-.razor:after {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  content: "";
-  background: inherit;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  transform-origin: top left;
-  z-index: -1;
-  transform-origin: top left;
-  transform: skewY(4deg);
 }

--- a/src/styles/Login.css
+++ b/src/styles/Login.css
@@ -18,38 +18,12 @@
   padding-bottom: 8vh;
 }
 
-@media only screen and (max-width: 1000px) {
+@media only screen and (max-width: 1024px) {
   .hidden-small {
     display: none;
   }
   .login-page-content {
     background-image: none;
-  }
-}
-
-.row {
-  position: relative;
-  width: 100%;
-}
-
-.row [class^="col"] {
-  float: left;
-  min-height: 0.125rem;
-}
-
-.row::after {
-  content: "";
-  display: table;
-  clear: both;
-}
-
-.col {
-  width: 50%;
-}
-
-@media only screen and (max-width: 1000px) {
-  .col {
-    width: 100%;
   }
 }
 
@@ -104,7 +78,7 @@
   box-sizing: border-box;
 }
 
-@media only screen and (max-width: 1000px) {
+@media only screen and (max-width: 1024px) {
   .login-modal {
     text-align: center;
   }
@@ -174,4 +148,8 @@
 .login-form-link:hover {
   color: #2d7799;
   text-decoration: underline;
+}
+
+.force-no-wrap {
+  white-space: nowrap;
 }

--- a/src/styles/Login.css
+++ b/src/styles/Login.css
@@ -76,11 +76,13 @@
   display: block;
   margin-top: 30px; /*modal distance from top of the screen*/
   box-sizing: border-box;
+  width: 50%;
 }
 
 @media only screen and (max-width: 1024px) {
   .login-modal {
     text-align: center;
+    width: 100%;
   }
 }
 

--- a/src/styles/SocialButton.css
+++ b/src/styles/SocialButton.css
@@ -1,35 +1,26 @@
-.login-button{
-    font-family: 'Josefin Slab', sans-serif;
-    color: rgb(255, 255, 255);
-    cursor: pointer;
-    overflow: visible;
-    text-align: center;
-    border: 1px solid rgba(0, 0, 0, 0.09);
-    margin: 0px 0px 16px;
-    border-radius: 3px;							
-    user-select: none;
-    text-decoration: none;
-    width: 100%;								
-    padding: 16px;								
-    font-size: 16px;
-    line-height: 1.4em;
-    background-color: rgb(221, 75, 57);
+.login-button {
+  display: inline-block;
+  font-family: "Josefin Slab", sans-serif;
+  color: rgb(255, 255, 255);
+  cursor: pointer;
+  overflow: visible;
+  text-align: center;
+  border: 1px solid rgba(0, 0, 0, 0.09);
+  border-radius: 3px;
+  user-select: none;
+  text-decoration: none;
+  padding: 0.5em 1em;
+  margin-top: 1em;
+  font-size: 1.3rem;
+  line-height: 1.4em;
+  background-color: rgb(221, 75, 57);
+  margin-right: 0.5em;
 }
 
-.login-button-content{
-    justify-content: center;	
-    align-items: center;
-    display: flex;
-}
-
-.login-button-img{
-    position: absolute;			/*absolute to make it right next to the edge of hte box*/
-    left: 10px;
-    height: 24px;
-    width: 24px;
-}
-
-.login-button-text{				
-    position: relative;			/*relative to make it depend on the image*/
-    left: 10px;					/*textPadding changes this value, i.e. 10 is the default*/
+.login-button-img {
+  display: inline-block;
+  height: 1em;
+  width: 1em;
+  margin-left: 0.5em;
+  margin-right: 0.5em;
 }

--- a/src/styles/SocialButton.css
+++ b/src/styles/SocialButton.css
@@ -16,11 +16,3 @@
   background-color: rgb(221, 75, 57);
   margin-right: 0.5em;
 }
-
-.login-button-img {
-  display: inline-block;
-  height: 1em;
-  width: 1em;
-  margin-left: 0.5em;
-  margin-right: 0.5em;
-}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -8,7 +8,7 @@ body,
 
 body {
   font-family: "Josefin Slab", sans-serif;
-  min-width: 1125px;
+  /*min-width: 1125px;*/
   overflow: hidden;
   box-sizing: border-box;
 }


### PR DESCRIPTION
This PR makes the Login and Create User pages more responsive - the forms now resize properly based on the viewport width, and the illustration scales appropriately and disappears when the viewport is too small.

In addition, I clean up a lot of the CSS & HTML behind the pages - but there's a lot more work to be done, probably in a refactor that creates just one Login component (opposed to the Modal & the Input), cleans up the styles even further into reusable components (which could involve a lot of renaming), and makes the Create User page independent of Login's styling (which is technically bad practice).