### PR TITLE
Automatically Deploys to gh-pages on successful master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ cache:
 script:
   - npm run prod_build
 
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $github_token
+  local_dir: build
+  on:
+    branch: master
+
 notifications:
   email:
     on_success: never

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "teachla-frontend",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://uclaacm.github.io/TeachLAFrontend",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.17",
     "@fortawesome/free-solid-svg-icons": "^5.8.1",


### PR DESCRIPTION
I've changed the `.travis.yml` to automatically deploy the results of `npm run prod_build` to the `gh-pages` branch. Also note that for now, I've changed the project root to accompany GitHub Pages' naming scheme - if we get a domain, we need to change this.