### PR TITLE
Adds Download Sketch Button

### DIFF
--- a/src/components/Sketches/components/SketchBox.js
+++ b/src/components/Sketches/components/SketchBox.js
@@ -3,6 +3,7 @@ import React from "react";
 import "../../../styles/Sketches.css";
 
 import { Row, Col } from "reactstrap";
+import { faDownload } from "@fortawesome/free-solid-svg-icons";
 import { faEdit } from "@fortawesome/free-solid-svg-icons";
 import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -30,6 +31,10 @@ class SketchBox extends React.Component {
         <Row className="sketch-box-body">
           <Col className="p-2 text-center" onClick={this.props.editFunc}>
             <FontAwesomeIcon className="fa-lg" icon={faEdit} />
+          </Col>
+          <div className="sketch-button-divider" />
+          <Col className="p-2 text-center" onClick={this.props.downloadFunc}>
+            <FontAwesomeIcon className="fa-lg" icon={faDownload} />
           </Col>
           <div className="sketch-button-divider" />
           <Col className="p-2 text-center" onClick={this.props.deleteFunc}>

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -36,6 +36,30 @@ class Sketches extends React.Component {
     return SketchThumbnailArray[Math.floor(Math.random() * SketchThumbnailArray.length)];
   };
 
+  downloadSketchCode = (name, language, code) => {
+    let extension = ".";
+    switch (language) {
+      case "python":
+        extension += "py";
+        break;
+      case "processing":
+        extension += "processing";
+        break;
+      case "html":
+        extension += "html";
+        break;
+      default:
+        extension += "txt";
+    }
+    // taken from this: https://stackoverflow.com/questions/44656610/download-a-string-as-txt-file-in-react
+    const element = document.createElement("a");
+    const file = new Blob([code], { type: "text/plain" });
+    element.href = URL.createObjectURL(file);
+    element.download = name + extension;
+    document.body.appendChild(element); // Required for this to work in FireFox
+    element.click();
+  };
+
   setCreateSketchModalOpen = val => {
     this.setState({ createSketchModalOpen: val });
   };
@@ -89,8 +113,7 @@ class Sketches extends React.Component {
       // if (a.name > b.name) return 1;
       else return 1;
     });
-
-    newList.forEach(({ key, name, language, thumbnail }) => {
+    newList.forEach(({ key, name, language, thumbnail, code }) => {
       let faLanguage;
       let languageDisplay; // not a great way to do this!
       switch (language) {
@@ -115,6 +138,9 @@ class Sketches extends React.Component {
           key={key}
           deleteFunc={() => {
             this.setConfirmDeleteModalOpen(true, name, key);
+          }}
+          downloadFunc={() => {
+            this.downloadSketchCode(name, language, code);
           }}
           editFunc={() => {
             this.setEditSketchModalOpen(

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -7,6 +7,7 @@ import CreateSketchModalContainer from "./containers/CreateSketchModalContainer"
 import EditSketchModalContainer from "./containers/EditSketchModalContainer";
 import OpenPanelButtonContainer from "../common/containers/OpenPanelButtonContainer";
 import { SketchThumbnailArray } from "./constants";
+import ProcessingConstructor from "../Editor/components/Output/Processing";
 // import { PANEL_SIZE } from "../../constants";
 import "../../styles/Sketches.css";
 
@@ -42,9 +43,7 @@ class Sketches extends React.Component {
       case "python":
         extension += "py";
         break;
-      case "processing":
-        extension += "processing";
-        break;
+      case "processing": // this is because we construct the processing result as an HTML file. jank.
       case "html":
         extension += "html";
         break;
@@ -53,7 +52,12 @@ class Sketches extends React.Component {
     }
     // taken from this: https://stackoverflow.com/questions/44656610/download-a-string-as-txt-file-in-react
     const element = document.createElement("a");
-    const file = new Blob([code], { type: "text/plain" });
+    let file;
+    if (language === "processing") {
+      file = new Blob([ProcessingConstructor(code, true)], { type: "text/plain" });
+    } else {
+      file = new Blob([code], { type: "text/plain" });
+    }
     element.href = URL.createObjectURL(file);
     element.download = name + extension;
     document.body.appendChild(element); // Required for this to work in FireFox


### PR DESCRIPTION
This is a pretty small PR that adds a "Download Sketch" button to each sketch in the sketches page. Two quick things before we merge:
1. Do we want to have a download page on the editor too? If so, what scope is the download function going to have?
2. What's the correct extension for processing? I've seen both `.processing` and `.pde`