### PR TITLE
Fixes placement of editor's cursor arrow in Firefox

### DIFF
--- a/src/styles/CustomCM.css
+++ b/src/styles/CustomCM.css
@@ -93,6 +93,13 @@
   background-image: url("./triangle.png");
 }
 
+/* required for firefox because it places the ::after element differently than chrome */
+@-moz-document url-prefix() {
+  .cm-s-material .CodeMirror-cursor::after {
+    margin-top: 26px;
+  }
+}
+
 .CodeMirror-scroll {
   overflow: hidden !important;
 }


### PR DESCRIPTION
I think this issue boils down to Firefox placing the `::after` pseudo-element in a different location than Chrome for the cursor. Could also be a CodeMirror problem.

(*note:* tested on Firefox Quantum 67.0)

Should probably do testing on IE & Edge, unfortunately I don't have a Windows computer. 