### PR TITLE
Uses <Link> instead of <Redirect> for (some) Rerouting

### DIFF
--- a/src/components/Sketches/components/SketchBox.js
+++ b/src/components/Sketches/components/SketchBox.js
@@ -1,5 +1,5 @@
 import React from "react";
-
+import { Link } from "react-router-dom";
 import "../../../styles/Sketches.css";
 
 import { Row, Col } from "reactstrap";
@@ -12,7 +12,11 @@ class SketchBox extends React.Component {
   render() {
     return (
       <div className="sketch-box">
-        <div className="sketch-box-body" onClick={this.props.redirFunc}>
+        <Link
+          className="sketch-box-body"
+          onClick={this.props.redirFunc}
+          to={{ pathname: "/editor" }}
+        >
           <img
             alt={"User's sketch icon"}
             src={`${process.env.PUBLIC_URL}/img/sketch-thumbnails/${this.props.img}.svg`}
@@ -26,7 +30,7 @@ class SketchBox extends React.Component {
               <FontAwesomeIcon className="fa-lg" icon={this.props.icon} />
             </Col>
           </Row>
-        </div>
+        </Link>
         <hr className="sketch-divider" />
         <Row className="sketch-box-body">
           <Col className="p-2 text-center" onClick={this.props.editFunc}>

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { Redirect } from "react-router-dom";
 import SketchBox from "./components/SketchBox";
 import ConfirmDeleteModalContainer from "./containers/ConfirmDeleteModalContainer";
 import CreateSketchModalContainer from "./containers/CreateSketchModalContainer";
@@ -25,7 +24,6 @@ class Sketches extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      redirectTo: "",
       confirmDeleteModalOpen: false,
       createSketchModalOpen: false,
       editSketchModalOpen: false,
@@ -85,9 +83,8 @@ class Sketches extends React.Component {
     });
   };
 
-  redirectToEditor = name => {
+  setProgram = name => {
     this.props.setMostRecentProgram(name);
-    this.setState({ redirectTo: "/editor" });
   };
 
   renderHeader = () => (
@@ -175,7 +172,7 @@ class Sketches extends React.Component {
             );
           }}
           redirFunc={() => {
-            this.redirectToEditor(key);
+            this.setProgram(key);
           }}
         />,
       );
@@ -234,10 +231,6 @@ class Sketches extends React.Component {
   };
 
   render() {
-    if (this.state.redirectTo) {
-      return <Redirect to={this.state.redirectTo} />;
-    }
-
     const containerStyle = {
       left: this.props.left || 0,
       width: this.props.calculatedWidth,

--- a/src/components/common/ProfilePanel.js
+++ b/src/components/common/ProfilePanel.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Redirect } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { Button } from "reactstrap";
 import firebase from "firebase";
 import {
@@ -34,7 +34,6 @@ class ProfilePanel extends React.Component {
       name: this.props.displayName,
       selectedImage: "",
       displayNameMessage: "",
-      redirectTo: "",
     };
   }
 
@@ -205,33 +204,25 @@ class ProfilePanel extends React.Component {
   };
 
   renderEditorButton = () => (
-    <Button
-      className="panel-button"
-      key="editor-button"
-      size="lg"
-      block
-      onClick={() => {
-        this.setState({ redirectTo: "/editor" });
-      }}
+    <Link
+      to={{ pathname: "/editor" }}
+      className="panel-button btn btn-secondary btn-lg btn-block"
+      key="sketches-button"
     >
       <FontAwesomeIcon icon={faPencilAlt} />
       <span className="panel-button-text">Editor</span>
-    </Button>
+    </Link>
   );
 
   renderSketchesButton = () => (
-    <Button
-      className="panel-button"
+    <Link
+      to={{ pathname: "/sketches" }}
+      className="panel-button btn btn-secondary btn-lg btn-block"
       key="sketches-button"
-      size="lg"
-      block
-      onClick={() => {
-        this.setState({ redirectTo: "/sketches" });
-      }}
     >
       <FontAwesomeIcon icon={faBook} />
       <span className="panel-button-text">Sketches</span>
-    </Button>
+    </Link>
   );
 
   renderSignOutButton = () => (
@@ -266,13 +257,6 @@ class ProfilePanel extends React.Component {
     return <div className="panel-buttons">{panelButtons}</div>;
   };
 
-  renderRedirect() {
-    if (this.state.redirectTo) {
-      return <Redirect to={this.state.redirectTo} />;
-    }
-    return null;
-  }
-
   renderContent = () => (
     <div className="panel-content">
       {this.renderPanelImage()}
@@ -299,7 +283,6 @@ class ProfilePanel extends React.Component {
       <div className="panel" style={panelStyle}>
         {this.renderCollapseButton()}
         {this.renderContent()}
-        {this.renderRedirect()}
         <Footer />
       </div>
     );

--- a/src/styles/Sketches.css
+++ b/src/styles/Sketches.css
@@ -78,9 +78,15 @@
 }
 
 .sketch-box-body {
+  color: inherit;
   width: 90%;
   margin-left: auto;
   margin-right: auto;
+}
+
+.sketch-box-body:hover {
+  color: inherit;
+  text-decoration: none;
 }
 
 .sketch-divider {


### PR DESCRIPTION
This addresses a bug brought up in PR #52 - namely, that navigating to a newly created sketch, then clicking "sketches" doesn't bring the user back to the sketches view.

This PR swaps out the state-based loading of the `<Redirect>` component with directly using the `<Link>` component on the button that triggers the redirect. Now, the behaviour described above works as intended - this PR meets the bare minimum of fixing the bug.

Note that right now, this is only implemented on the Profile Panel's buttons (Editor, Sketches) and the individual Sketch Box button (that redirects to the editor) - this is because these two are guaranteed switches, while two other uses of `<Redirect>` (redirecting to sketches if the editor is empty, and the create sketch button only redirecting after the sketch has been successfully created) are conditional and cannot be replaced with `<Link>` by themselves. However, I'm open to any suggestions.