### PR TITLE
Reverts react-redux to 5.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14396,16 +14396,17 @@
       }
     },
     "react-redux": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.1.1.tgz",
-      "integrity": "sha512-QsW0vcmVVdNQzEkrgzh2W3Ksvr8cqpAv5FhEk7tNEft+5pp7rXxAudTz3VOPawRkLIepItpkEIyLcN/VVXzjTg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
+      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
       "requires": {
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.1.2",
         "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.9.0"
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.1",
+        "react-is": "^16.6.0",
+        "react-lifecycles-compat": "^3.0.0"
       }
     },
     "react-redux-firebase": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-codemirror2": "^4.2.1",
     "react-dom": "^16.11.0",
     "react-modal": "^3.8.1",
-    "react-redux": "^7.1.1",
+    "react-redux": "^5.1.1",
     "react-redux-firebase": "^2.1.6",
     "react-router": "^5.1.2",
     "react-router-dom": "^4.2.2",

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -9,7 +9,7 @@ import PageNotFound from "./PageNotFound";
 import firebase from "firebase";
 import "styles/app.scss";
 
-const provider = new firebase.auth.FacebookAuthProvider();
+const provider = new firebase.auth.EmailAuthProvider();
 
 class App extends React.Component {
   constructor(props) {
@@ -30,7 +30,7 @@ class App extends React.Component {
     window.addEventListener("resize", this.handleResize, true);
   };
 
-  componentWillUnmout = () => {
+  componentWillUnmount = () => {
     window.removeEventListener("resize", this.handleResize, true);
   };
 


### PR DESCRIPTION
Turns out that we weren't good to merge react-redux `7.*` into our codebase since it causes an issue with `react-redux-firebase`, and I wasn't able to resolve it quickly. Merging this until we can deal with the problem.