### PR TITLE
Fixes Cursor Position for Chrome

### DIFF
--- a/src/styles/CustomCM.scss
+++ b/src/styles/CustomCM.scss
@@ -82,7 +82,7 @@
 
 .cm-s-material .CodeMirror-cursor::after {
   position: absolute;
-  margin-top: 2px;
+  margin-top: 26px;
   left: -10px;
   color: rgba(255, 255, 255, 0);
   content: "";
@@ -93,13 +93,6 @@
   background-size: 20px auto;
   background-repeat: no-repeat;
   background-image: url("./triangle.png");
-}
-
-/* required for firefox because it places the ::after element differently than chrome */
-@-moz-document url-prefix() {
-  .cm-s-material .CodeMirror-cursor::after {
-    margin-top: 26px;
-  }
 }
 
 .CodeMirror-scroll {

--- a/src/styles/CustomCM.scss
+++ b/src/styles/CustomCM.scss
@@ -95,6 +95,13 @@
   background-image: url("./triangle.png");
 }
 
+/* required for safari because it places the ::after element differently than chrome/fiefox; taken from https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari-only-not-chrome */
+@media not all and (min-resolution:.001dpcm) { 
+  .cm-s-material .CodeMirror-cursor::after {
+    margin-top: 2px;
+  }
+
+}
 .CodeMirror-scroll {
   overflow: hidden !important;
 }


### PR DESCRIPTION
Chrome has updated their `::after` to be similar to Firefox's behavior (#55), so this updates the base default to use the "new" behavior, and adds a Safari exception. Needs more field testing.