### PR TITLE
Turn "Save" and "Run" into icon buttons when screen gets too small

### DIFF
--- a/src/components/Editor/components/Output.js
+++ b/src/components/Editor/components/Output.js
@@ -158,7 +158,7 @@ class Output extends React.Component {
       {this.renderConsoleButton()}
       <Button className="mx-2" color="primary" size="lg" onClick={this.runCode}>
         <FontAwesomeIcon icon={faPlay} />
-        {!this.props.isSmall && <span className="btn-text">&nbsp;&nbsp;Run</span>}
+        {!this.props.isSmall && <span className="editor-button-text">&nbsp;&nbsp;Run</span>}
       </Button>
     </div>
   );

--- a/src/components/Editor/components/Output.js
+++ b/src/components/Editor/components/Output.js
@@ -158,7 +158,7 @@ class Output extends React.Component {
       {this.renderConsoleButton()}
       <Button className="mx-2" color="primary" size="lg" onClick={this.runCode}>
         <FontAwesomeIcon icon={faPlay} />
-        &nbsp;&nbsp;Run
+        <span className="btn-text">&nbsp;&nbsp;Run</span>
       </Button>
     </div>
   );

--- a/src/components/Editor/components/Output.js
+++ b/src/components/Editor/components/Output.js
@@ -158,7 +158,7 @@ class Output extends React.Component {
       {this.renderConsoleButton()}
       <Button className="mx-2" color="primary" size="lg" onClick={this.runCode}>
         <FontAwesomeIcon icon={faPlay} />
-        <span className="btn-text">&nbsp;&nbsp;Run</span>
+        {!this.props.isSmall && <span className="btn-text">&nbsp;&nbsp;Run</span>}
       </Button>
     </div>
   );

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -136,7 +136,7 @@ class Editor extends React.Component {
         <Button className="mx-2" color="success" size="lg" onClick={this.handleSave}>
           <FontAwesomeIcon icon={faSave} />
           {this.props.screenWidth > EDITOR_WIDTH_BREAKPOINT && (
-            <span className="btn-text">&nbsp;&nbsp;{this.state.saveText}</span>
+            <span className="editor-button-text">&nbsp;&nbsp;{this.state.saveText}</span>
           )}
         </Button>
       </div>

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -135,7 +135,7 @@ class Editor extends React.Component {
         </div>
         <Button className="mx-2" color="success" size="lg" onClick={this.handleSave}>
           <FontAwesomeIcon icon={faSave} />
-          &nbsp;&nbsp;{this.state.saveText}
+          <span className="btn-text">&nbsp;&nbsp;{this.state.saveText}</span>
         </Button>
       </div>
       <div

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -135,7 +135,9 @@ class Editor extends React.Component {
         </div>
         <Button className="mx-2" color="success" size="lg" onClick={this.handleSave}>
           <FontAwesomeIcon icon={faSave} />
-          <span className="btn-text">&nbsp;&nbsp;{this.state.saveText}</span>
+          {this.props.screenWidth > EDITOR_WIDTH_BREAKPOINT && (
+            <span className="btn-text">&nbsp;&nbsp;{this.state.saveText}</span>
+          )}
         </Button>
       </div>
       <div

--- a/src/styles/Editor.scss
+++ b/src/styles/Editor.scss
@@ -123,3 +123,9 @@
 .text-editor-container::-webkit-scrollbar-thumb:hover {
   background: #2f2d33;
 }
+
+@media (max-width:1200px) {
+  .btn-text {
+    display: none;
+  }
+}

--- a/src/styles/Editor.scss
+++ b/src/styles/Editor.scss
@@ -123,9 +123,3 @@
 .text-editor-container::-webkit-scrollbar-thumb:hover {
   background: #2f2d33;
 }
-
-@media (max-width:1200px) {
-  .btn-text {
-    display: none;
-  }
-}


### PR DESCRIPTION
This is a super tiny PR but here's what it includes:
* Add `.editor-button-text` class. It is currently applied to the "Save" and "Run" labels for the editor. There are no custom styles for it as of this writing.
* Conditionally render "Save" and "Run" labels when the screen is not "too small"
    - "Too small" means that the viewport meets the requirement for `isSmall`: the screen width is less than or equal to the `EDITOR_WIDTH_BREAKPOINT` constant in `Editor/constants/index.js`.