### PR TITLE
Auditing Node Deps: Removing Unused, Relocating enzyme-adapter...

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2426,6 +2426,7 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
       "integrity": "sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==",
+      "dev": true,
       "requires": {
         "array.prototype.find": "^2.1.0",
         "function.prototype.name": "^1.1.1",
@@ -2613,6 +2614,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
       "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.13.0"
@@ -3635,11 +3637,6 @@
         "supports-color": "^2.0.0"
       }
     },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -3757,12 +3754,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "circular-json": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
-      "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==",
-      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -5174,6 +5165,7 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.1.tgz",
       "integrity": "sha512-yMPxrP3vjJP+4wL/qqfkT6JAIctcwKF+zXO6utlGPgUJT2l4tzrdjMDWGd/Pp1BjHBcljhN24OzNEGRteibJhA==",
+      "dev": true,
       "requires": {
         "enzyme-adapter-utils": "^1.12.1",
         "enzyme-shallow-equal": "^1.0.0",
@@ -5189,7 +5181,8 @@
         "react-is": {
           "version": "16.10.2",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
-          "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+          "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==",
+          "dev": true
         }
       }
     },
@@ -5197,6 +5190,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.1.tgz",
       "integrity": "sha512-KWiHzSjZaLEoDCOxY8Z1RAbUResbqKN5bZvenPbfKtWorJFVETUw754ebkuCQ3JKm0adx1kF8JaiR+PHPiP47g==",
+      "dev": true,
       "requires": {
         "airbnb-prop-types": "^2.15.0",
         "function.prototype.name": "^1.1.1",
@@ -5210,6 +5204,7 @@
           "version": "1.15.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
           "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.0",
             "function-bind": "^1.1.1",
@@ -5227,6 +5222,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
           "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "es-abstract": "^1.15.0",
@@ -5240,6 +5236,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.0.tgz",
       "integrity": "sha512-VUf+q5o1EIv2ZaloNQQtWCJM9gpeux6vudGVH6vLmfPXFLRuxl5+Aq3U260wof9nn0b0i+P5OEUXm1vnxkRpXQ==",
+      "dev": true,
       "requires": {
         "has": "^1.0.3",
         "object-is": "^1.0.1"
@@ -6229,35 +6226,6 @@
         "bser": "^2.0.0"
       }
     },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        }
-      }
-    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -7196,6 +7164,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.1.tgz",
       "integrity": "sha512-e1NzkiJuw6xqVH7YSdiW/qDHebcmMhPNe6w+4ZYYEg0VA+LaLzx37RimbPLuonHhYGFGPx1ME2nSi74JiaCr/Q==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1",
@@ -7211,7 +7180,8 @@
     "functions-have-names": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.1.1.tgz",
-      "integrity": "sha512-U0kNHUoxwPNPWOJaMG7Z00d4a/qZVrFtzWJRaK8V9goaVOCXBSQSJpt3MYGNtkScKEBKovxLjnNdC9MlXwo5Pw=="
+      "integrity": "sha512-U0kNHUoxwPNPWOJaMG7Z00d4a/qZVrFtzWJRaK8V9goaVOCXBSQSJpt3MYGNtkScKEBKovxLjnNdC9MlXwo5Pw==",
+      "dev": true
     },
     "gauge": {
       "version": "2.7.4",
@@ -13973,6 +13943,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
       "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+      "dev": true,
       "requires": {
         "has": "^1.0.3",
         "object.assign": "^4.1.0",
@@ -14469,11 +14440,6 @@
         }
       }
     },
-    "react-router-redux": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/react-router-redux/-/react-router-redux-4.0.8.tgz",
-      "integrity": "sha1-InQDWWtRUeGCN32rg1tdRfD4BU4="
-    },
     "react-scripts": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.2.0.tgz",
@@ -14577,6 +14543,7 @@
       "version": "16.10.2",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.10.2.tgz",
       "integrity": "sha512-k9Qzyev6cTIcIfrhgrFlYQAFxh5EEDO6ALNqYqmKsWVA7Q/rUMTay5nD3nthi6COmYsd4ghVYyi8U86aoeMqYQ==",
+      "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
@@ -14664,26 +14631,6 @@
         "util.promisify": "^1.0.0"
       }
     },
-    "recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        }
-      }
-    },
     "recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -14701,11 +14648,6 @@
         "strip-indent": "^1.0.1"
       }
     },
-    "reduce-reducers": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-1.0.4.tgz",
-      "integrity": "sha512-Mb2WZ2bJF597exiqX7owBzrqJ74DHLK3yOQjCyPAaNifRncE8OD0wFIuoMhXxTnHK07+8zZ2SJEKy/qtiyR7vw=="
-    },
     "redux": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
@@ -14715,32 +14657,11 @@
         "symbol-observable": "^1.2.0"
       }
     },
-    "redux-firestore": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/redux-firestore/-/redux-firestore-0.9.0.tgz",
-      "integrity": "sha512-Y8kX8DJzpTBR5rp+bg5SiTxzaROcQmjU5ctYADreCSLqavhGMzcr8edcMKtA0cF5NTk4u6kfDLmynNDJD4b5kA==",
-      "requires": {
-        "immer": "3.2.0",
-        "lodash": "^4.17.15",
-        "reduce-reducers": "^1.0.4"
-      },
-      "dependencies": {
-        "immer": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/immer/-/immer-3.2.0.tgz",
-          "integrity": "sha512-+a2R8z9eELHst6aht++nzVzJ8LJ+Hsg49qttfg9Kc/vmoxEdPXw5/rV6+4DYWGgnq+B36KbLr4OTaGtS9mDjtg=="
-        }
-      }
-    },
-    "redux-thunk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
-    },
     "reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.0",
@@ -15325,6 +15246,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-BqYVWqwz6s1wZMhjFvLfVR5WXP7ZY32M/wYPo04CcuPM7XZEbV2TBNW7Z0UkguPTl0dWMA59VbNXxK6q+pHItg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -16679,11 +16601,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/package.json
+++ b/package.json
@@ -8,16 +8,13 @@
     "@fortawesome/free-brands-svg-icons": "^5.11.2",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.7",
-    "ajv": "^6.4.0",
     "bootstrap": ">=4.3.1",
     "codemirror": "^5.49.2",
     "cross-env": "^6.0.3",
     "crypto-js": "^3.1.9-1",
-    "enzyme-adapter-react-16": "^1.15.1",
     "firebase": "^7.2.2",
     "immutable": "^3.8.2",
     "node-sass": "^4.13.0",
-    "prop-types": "^15.6.2",
     "react": "^16.11.0",
     "react-codemirror2": "^6.0.0",
     "react-dom": "^16.11.0",
@@ -25,15 +22,11 @@
     "react-redux": "^5.1.1",
     "react-router": "^5.1.2",
     "react-router-dom": "^4.2.2",
-    "react-router-redux": "^4.0.8",
     "react-scripts": "3.2.0",
     "react-spinners": "^0.6.1",
     "react-split-pane": "^0.1.87",
     "reactstrap": "^8.1.1",
-    "recompose": "^0.30.0",
-    "redux": "^4.0.0",
-    "redux-firestore": "^0.9.0",
-    "redux-thunk": "^2.3.0"
+    "redux": "^4.0.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -45,8 +38,8 @@
     "prod_build": "cross-env REACT_APP_FS_PROJ=prod REACT_APP_SERVER_TYPE=prod react-scripts build"
   },
   "devDependencies": {
-    "circular-json": "^0.5.5",
     "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.15.1",
     "enzyme-to-json": "^3.4.3",
     "husky": "^3.0.9",
     "lint-staged": "^9.4.2",


### PR DESCRIPTION
Looks like we have some fall cleaning to do! We can lower our dev installation and bundle size by getting rid of a few dependencies we don't use:
* `ajv`
* `prop-types` - though this might be worthwhile to reintroduce later
* `react-router-redux`
* `recompose`
* `redux-firestore`
* `redux-thunk` - though we might revisit this later
* `circular-json`

In addition, `enzyme-adapter-react-16` was erroneously installed as a dependency instead of a devDependency, so I've moved it to the correct field.