### PR TITLE
Updates skulpt to v1.1.0

### DIFF
--- a/src/components/Editor/components/Output/Python.js
+++ b/src/components/Editor/components/Output/Python.js
@@ -1,8 +1,8 @@
 const getPythonSrcDocHead = () => `
 <head>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js" type="text/javascript"></script>
-  <script src="https://cdn.rawgit.com/skulpt/skulpt-dist/0.11.0/skulpt.min.js" type="text/javascript"></script>
-  <script src="https://cdn.rawgit.com/skulpt/skulpt-dist/0.11.0/skulpt-stdlib.js" type="text/javascript"></script>
+  <script src="https://cdn.rawgit.com/skulpt/skulpt-dist/1.1.0/skulpt.min.js" type="text/javascript"></script>
+  <script src="https://cdn.rawgit.com/skulpt/skulpt-dist/1.1.0/skulpt-stdlib.js" type="text/javascript"></script>
   <style> html, body { margin:0; background-color: #585166;}
           #inner {
             height:100px;


### PR DESCRIPTION
After receiving some feedback from the instructors, bumping up the skulpt version might improve some reliability we'll get out of the Python "interpreter". 

Two other quick notes: we should support both Python 2 and Python 3, and this entire component is super jank.