### PR TITLE
Resizes Default Ratio of Code:Output to be 3:2

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -108,7 +108,9 @@ class Editor extends React.Component {
         (this.props.panelOpen ? this.props.screenWidth - PANEL_SIZE : this.props.screenWidth) * 0.75
       } //max size of code is 75% of the remaining screen size
       size={
-        (this.props.panelOpen ? this.props.screenWidth - PANEL_SIZE : this.props.screenWidth) / 2
+        ((this.props.panelOpen ? this.props.screenWidth - PANEL_SIZE : this.props.screenWidth) /
+          5) *
+        3
       } //the initial size of the text editor section
       allowResize={true}
     >


### PR DESCRIPTION
This is a quick PR that changes the default ratio of Code : Output components on the Editor to be 3:2, which gives us more breathing space in the top of the code editing pane.