### PR TITLE
Updates Unsafe Lifecycles

### DIFF
--- a/src/components/Editor/components/TextEditor.js
+++ b/src/components/Editor/components/TextEditor.js
@@ -31,8 +31,6 @@ class TextEditor extends React.Component {
     window.addEventListener("close", this.onLeave);
   }
 
-  componentWillUpdate() {}
-
   componentWillUnmount = () => {
     window.removeEventListener("beforeunload", this.onLeave);
     window.removeEventListener("close", this.onLeave);

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -38,7 +38,7 @@ class Editor extends React.Component {
   }
 
   //==============React Lifecycle Functions Start===================//
-  componentWillMount() {
+  componentDidMount() {
     if (this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT) {
       this.setState({ viewMode: CODE_ONLY });
     }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -31,22 +31,13 @@ class Editor extends React.Component {
     super(props);
     this.state = {
       saveText: "Save",
-      viewMode: CODE_AND_OUTPUT,
-      redirect: "",
+      viewMode: (this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT) ? CODE_ONLY : CODE_AND_OUTPUT,
+      redirect: (this.props.listOfPrograms.length === 0) ? "/sketches" : "",
       pane1Style: { transition: "width .5s ease" },
     };
   }
 
   //==============React Lifecycle Functions Start===================//
-  componentDidMount() {
-    if (this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT) {
-      this.setState({ viewMode: CODE_ONLY });
-    }
-    if (this.props.listOfPrograms.length === 0) {
-      this.setState({ redirect: "/sketches" });
-    }
-  }
-
   componentDidUpdate(prevProps) {
     if (this.props.screenWidth !== prevProps.screenWidth) {
       if (this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT) {

--- a/src/components/Sketches/components/ConfirmDeleteModal.js
+++ b/src/components/Sketches/components/ConfirmDeleteModal.js
@@ -4,9 +4,6 @@ import { Container, Row, Col, Button } from "reactstrap";
 import * as fetch from "../../../lib/fetch.js";
 
 class ConfirmDeleteModal extends React.Component {
-  componentWillMount() {}
-  componentDidUpdate() {}
-
   closeModal = () => {
     if (this.props.onClose && {}.toString.call(this.props.onClose) === "[object Function]") {
       this.props.onClose();

--- a/src/components/Sketches/components/CreateSketchModal.js
+++ b/src/components/Sketches/components/CreateSketchModal.js
@@ -29,9 +29,6 @@ class CreateSketchModal extends React.Component {
   }
 
   //==============React Lifecycle Functions Start===================//
-  componentWillMount() {}
-
-  componentDidUpdate() {}
 
   closeModal = () => {
     if (this.props.onClose && {}.toString.call(this.props.onClose) === "[object Function]") {

--- a/src/components/Sketches/components/EditSketchModal.js
+++ b/src/components/Sketches/components/EditSketchModal.js
@@ -20,8 +20,6 @@ class EditSketchModal extends React.Component {
       onThumbnails: false,
     };
   }
-  componentWillMount() {}
-  componentDidUpdate() {}
 
   closeModal = () => {
     if (this.props.onClose && {}.toString.call(this.props.onClose) === "[object Function]") {

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -21,9 +21,8 @@ class App extends React.Component {
   }
 
   //==============React Lifecycle Functions===================//
-  componentDidUpdate(a, b) {}
 
-  componentWillMount = () => {
+  componentDidMount = () => {
     firebase.auth().onAuthStateChanged(async user => {
       await this.onAuthHandler(user);
     });


### PR DESCRIPTION
This is a PR that updates the "UNSAFE" lifecycles mentioned in [this blog post](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html), namely for us `componentWillMount`. Mostly, this PR just removes stubs of functions that were never used, but it also changes `componentWillMount` to `componentDidMount` in `app.js` and `Editor/index.js`; the event listeners still function as intended.

As a note, we'll also have to greenlight the new `react-router-dom` version to fully remove all of the warnings.