### PR TITLE
Fixes incorrect usage of <Link> in Error component

### DIFF
--- a/src/components/Error.js
+++ b/src/components/Error.js
@@ -4,28 +4,30 @@ import Footer from "./common/Footer";
 import { Link } from "react-router-dom";
 import firebase from "firebase";
 import "styles/Page.scss";
+import { GH_REPO_NAME } from "../constants";
 
 class Error extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
-
   render() {
     return (
       <div className="page-container">
         <h2>Uh oh, something went wrong!</h2>
         <h1>Error: {this.props.errorMsg}</h1>
         <br />
+        <Button color="primary" size="lg" target="_blank" href={`${GH_REPO_NAME}/issues`}>
+          Let Us Know!
+        </Button>
+        &nbsp;
         <Link to="/">
           <Button color="success" size="lg">
             Back to safety
           </Button>
         </Link>
         &nbsp;
-        <Button color="danger" size="lg" onClick={() => firebase.auth().signOut()}>
-          Log Out
-        </Button>
+        {this.props.isValidUser && (
+          <Button color="danger" size="lg" onClick={() => firebase.auth().signOut()}>
+            Log Out
+          </Button>
+        )}
         <Footer />
       </div>
     );

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { BrowserRouter as Router, Route, Redirect, Switch } from "react-router-dom";
+import { ROUTER_BASE_NAME } from "../constants";
 import LoginPage from "./containers/LoginContainer";
 import MainContainer from "./containers/MainContainer";
 import LoadingPage from "./common/LoadingPage";
@@ -21,7 +22,6 @@ class App extends React.Component {
   }
 
   //==============React Lifecycle Functions===================//
-  componentDidUpdate(a, b) {}
 
   componentWillMount = () => {
     firebase.auth().onAuthStateChanged(async user => {
@@ -80,15 +80,11 @@ class App extends React.Component {
       return <LoadingPage />;
     }
 
-    if (this.props.errorMsg !== "") {
-      return <Error errorMsg={this.props.errorMsg} />;
-    }
-
     //the user is not valid if there's no UID
     let isValidUser = this.props.uid;
 
     return (
-      <Router basename="/TeachLAFrontend">
+      <Router basename={ROUTER_BASE_NAME}>
         <div className="App">
           <Switch>
             {/*if the user is loggedIn, redirect them to the editor, otherwise, show the login page*?*/}
@@ -96,33 +92,65 @@ class App extends React.Component {
               exact
               path="/"
               render={() =>
-                isValidUser ? <Redirect to="/editor" /> : <LoginPage provider={provider} />
+                this.props.errorMsg !== "" ? (
+                  <Error errorMsg={this.props.errorMsg} isValidUser={isValidUser} />
+                ) : isValidUser ? (
+                  <Redirect to="/editor" />
+                ) : (
+                  <LoginPage provider={provider} />
+                )
               }
             />
             {/*if the user is loggedIn, redirect them to the editor, otherwise, show the login page*?*/}
             <Route
               path="/login"
               render={() =>
-                isValidUser ? <Redirect to="/editor" /> : <LoginPage provider={provider} />
+                this.props.errorMsg !== "" ? (
+                  <Error errorMsg={this.props.errorMsg} isValidUser={isValidUser} />
+                ) : isValidUser ? (
+                  <Redirect to="/editor" />
+                ) : (
+                  <LoginPage provider={provider} />
+                )
               }
             />
             {/*if the user is not loggedIn, redirect them to the login page, otherwise, show the editor page*?*/}
             <Route
               path="/editor"
               render={() =>
-                !isValidUser ? <Redirect to="/login" /> : <MainContainer contentType="editor" />
+                this.props.errorMsg !== "" ? (
+                  <Error errorMsg={this.props.errorMsg} isValidUser={isValidUser} />
+                ) : !isValidUser ? (
+                  <Redirect to="/login" />
+                ) : (
+                  <MainContainer contentType="editor" />
+                )
               }
             />
             {/*if the user is loggedIn, redirect them to the editor page, otherwise, show the createUser page*?*/}
             <Route
               path="/createUser"
-              render={() => (isValidUser ? <Redirect to="/editor" /> : <CreateUserPage />)}
+              render={() =>
+                this.props.errorMsg !== "" ? (
+                  <Error errorMsg={this.props.errorMsg} isValidUser={isValidUser} />
+                ) : isValidUser ? (
+                  <Redirect to="/editor" />
+                ) : (
+                  <CreateUserPage />
+                )
+              }
             />
             {/*if the user isn't loggedIn, redirect them to the login page, otherwise, show the view page*?*/}
             <Route
               path="/sketches"
               render={() =>
-                isValidUser ? <MainContainer contentType="sketches" /> : <Redirect to="/login" />
+                this.props.errorMsg !== "" ? (
+                  <Error errorMsg={this.props.errorMsg} isValidUser={isValidUser} />
+                ) : isValidUser ? (
+                  <MainContainer contentType="sketches" />
+                ) : (
+                  <Redirect to="/login" />
+                )
               }
             />
             {/* Default error page */}
@@ -130,7 +158,7 @@ class App extends React.Component {
               path="/error"
               render={() =>
                 this.props.errorMsg ? (
-                  <Error errorMsg={this.props.errorMsg} />
+                  <Error errorMsg={this.props.errorMsg} isValidUser={isValidUser} />
                 ) : (
                   this.renderHome(isValidUser)
                 )

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -44,6 +44,12 @@ const PHOTO_NAMES = {
   heart: "https://i.imgur.com/ySz1WAS.png",
 };
 
+const GH_REPO_NAME = "https://github.com/uclaacm/TeachLAFrontend";
+
+// Router's base (i.e. anything after the domain)
+
+const ROUTER_BASE_NAME = "/TeachLAFrontend";
+
 //Local Server
 var SERVER_URL = "http://localhost:8081";
 if (process && process.env && process.env.REACT_APP_SERVER_TYPE === "prod") {
@@ -65,6 +71,11 @@ module.exports = {
   // photo names
   PHOTO_NAMES,
   DEFAULT_PHOTO_NAME: "icecream",
+
+  GH_REPO_NAME,
+
+  // Router Base Name
+  ROUTER_BASE_NAME,
 
   //Server Host Name
   SERVER_URL,


### PR DESCRIPTION
Previously, the `Error` component could get returned without a wrapping `<Router>` and/or `<Switch>`, which violates `react-router-dom`'s rules and makes it throw a very cryptic error. This PR fixes that, by making all calls to the `Error` component properly wrapped in an accompanying router. It also makes the `Error` component just a bit clearer.

(To reproduce the bug, force an error message app-wide, like having a wrong server URL)