### PR TITLE
Add download code button to main editor

### DIFF
--- a/src/components/Editor/containers/EditorContainer.js
+++ b/src/components/Editor/containers/EditorContainer.js
@@ -13,6 +13,8 @@ const mapStateToProps = state => {
   //should have 2 keys, code (which is the code) and langauge (which is the language the code is written it)
   const code = state.programs.getIn([mostRecentProgram, "code"], undefined);
   const dirty = state.programs.getIn([mostRecentProgram, "dirty"], false);
+  const name = state.programs.getIn([mostRecentProgram, "name"], "untitled");
+  const language = state.programs.getIn([mostRecentProgram, "language"], "txt");
 
   let listOfPrograms = [];
 
@@ -28,6 +30,8 @@ const mapStateToProps = state => {
     dirty,
     panelOpen: state.ui.panelOpen,
     left: (state.ui.panelOpen ? OPEN_PANEL_LEFT : CLOSED_PANEL_LEFT) + PANEL_SIZE,
+    name,
+    language,
   };
 };
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -9,6 +9,7 @@ import * as fetch from "../../lib/fetch.js";
 import EditorRadio from "./components/EditorRadio.js";
 import { Redirect } from "react-router-dom";
 import { EDITOR_WIDTH_BREAKPOINT, CODE_AND_OUTPUT, CODE_ONLY, OUTPUT_ONLY } from "./constants";
+import CodeDownloader from "./../../util/languages/CodeDownloader";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSave } from "@fortawesome/free-solid-svg-icons";
@@ -86,6 +87,10 @@ class Editor extends React.Component {
     this.props.cleanCode(this.props.mostRecentProgram); // Set code's "dirty" state to false
   };
 
+  handleDownload = () => {
+    new CodeDownloader().download(this.props.name, this.props.language, this.props.code);
+  };
+
   renderDropdown = () => <DropdownButtonContainer />;
 
   renderCodeAndOutput = () => (
@@ -143,7 +148,7 @@ class Editor extends React.Component {
           )}
         </Button>
 
-        <Button className="mx-2" color="success" size="lg" onClick={this.handleSave}>
+        <Button className="mx-2" color="success" size="lg" onClick={this.handleDownload}>
           <FontAwesomeIcon icon={faDownload} />
         </Button>
       </div>

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -134,7 +134,7 @@ class Editor extends React.Component {
       <div className="code-section-banner">
         <OpenPanelButtonContainer />
         {this.renderDropdown()}
-        <div style={{ marginLeft: "auto" }}>
+        <div style={{ marginLeft: "auto", marginRight: ".5rem" }}>
           <EditorRadio
             viewMode={this.state.viewMode}
             updateViewMode={this.updateViewMode}

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -12,6 +12,7 @@ import { EDITOR_WIDTH_BREAKPOINT, CODE_AND_OUTPUT, CODE_ONLY, OUTPUT_ONLY } from
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSave } from "@fortawesome/free-solid-svg-icons";
+import { faDownload } from "@fortawesome/free-solid-svg-icons";
 
 import { PANEL_SIZE } from "../../constants";
 import "codemirror/lib/codemirror.css";
@@ -140,6 +141,10 @@ class Editor extends React.Component {
           {this.props.screenWidth > EDITOR_WIDTH_BREAKPOINT && (
             <span className="editor-button-text">&nbsp;&nbsp;{this.state.saveText}</span>
           )}
+        </Button>
+
+        <Button className="mx-2" color="success" size="lg" onClick={this.handleSave}>
+          <FontAwesomeIcon icon={faDownload} />
         </Button>
       </div>
       <div

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -88,7 +88,7 @@ class Editor extends React.Component {
   };
 
   handleDownload = () => {
-    new CodeDownloader().download(this.props.name, this.props.language, this.props.code);
+    CodeDownloader.download(this.props.name, this.props.language, this.props.code);
   };
 
   renderDropdown = () => <DropdownButtonContainer />;

--- a/src/util/languages/CodeDownloader.js
+++ b/src/util/languages/CodeDownloader.js
@@ -1,3 +1,5 @@
+import ProcessingConstructor from "./../../components/Editor/components/Output/Processing";
+
 export default class CodeDownloader {
   download = (name, language, code) => {
     let extension = ".";

--- a/src/util/languages/CodeDownloader.js
+++ b/src/util/languages/CodeDownloader.js
@@ -1,0 +1,28 @@
+export default class CodeDownloader {
+  download = (name, language, code) => {
+    let extension = ".";
+    switch (language) {
+      case "python":
+        extension += "py";
+        break;
+      case "processing": // this is because we construct the processing result as an HTML file. jank.
+      case "html":
+        extension += "html";
+        break;
+      default:
+        extension += "txt";
+    }
+    // taken from this: https://stackoverflow.com/questions/44656610/download-a-string-as-txt-file-in-react
+    const element = document.createElement("a");
+    let file;
+    if (language === "processing") {
+      file = new Blob([ProcessingConstructor(code, true)], { type: "text/plain" });
+    } else {
+      file = new Blob([code], { type: "text/plain" });
+    }
+    element.href = URL.createObjectURL(file);
+    element.download = name + extension;
+    document.body.appendChild(element); // Required for this to work in FireFox
+    element.click();
+  };
+}

--- a/src/util/languages/CodeDownloader.js
+++ b/src/util/languages/CodeDownloader.js
@@ -1,7 +1,7 @@
 import ProcessingConstructor from "./../../components/Editor/components/Output/Processing";
 
 export default class CodeDownloader {
-  download = (name, language, code) => {
+  static download = (name, language, code) => {
     let extension = ".";
     switch (language) {
       case "python":


### PR DESCRIPTION
Adds this big nifty green button that downloads your code! Spiffy.

Also acts as a staging ground for future refactoring and code organization by splitting common download logic to downloader utility.


![download button](https://user-images.githubusercontent.com/10734915/68172524-86bafc80-ff3d-11e9-8fef-bd46f573415d.png)