### PR TITLE
Add ViewportAwareButton to Editor.

### DIFF
--- a/src/components/Editor/components/Output.js
+++ b/src/components/Editor/components/Output.js
@@ -8,6 +8,7 @@ import CreateProcessingDoc from "./Output/Processing";
 import CreatePythonDoc from "./Output/Python";
 
 import { Button } from "reactstrap";
+import ViewportAwareButton from "./ViewportAwareButton";
 
 import { faPlay } from "@fortawesome/free-solid-svg-icons";
 import { faTerminal } from "@fortawesome/free-solid-svg-icons";
@@ -156,10 +157,16 @@ class Output extends React.Component {
       <div style={{ flex: "1 1 auto" }}> </div> {/*whitespace*/}
       {this.renderRadio()}
       {this.renderConsoleButton()}
-      <Button className="mx-2" color="primary" size="lg" onClick={this.runCode}>
+      <ViewportAwareButton
+        className="mx-2"
+        color="primary"
+        size="lg"
+        onClick={this.runCode}
+        isSmall={this.props.isSmall}
+      >
         <FontAwesomeIcon icon={faPlay} />
-        {!this.props.isSmall && <span className="editor-button-text">&nbsp;&nbsp;Run</span>}
-      </Button>
+        <span className="editor-button-text viewport-aware">&nbsp;&nbsp;Run</span>
+      </ViewportAwareButton>
     </div>
   );
 

--- a/src/components/Editor/components/Output.js
+++ b/src/components/Editor/components/Output.js
@@ -163,10 +163,9 @@ class Output extends React.Component {
         size="lg"
         onClick={this.runCode}
         isSmall={this.props.isSmall}
-      >
-        <FontAwesomeIcon icon={faPlay} />
-        <span className="editor-button-text viewport-aware">&nbsp;&nbsp;Run</span>
-      </ViewportAwareButton>
+        icon={<FontAwesomeIcon icon={faPlay} />}
+        text="Run"
+      />
     </div>
   );
 

--- a/src/components/Editor/components/ViewportAwareButton.js
+++ b/src/components/Editor/components/ViewportAwareButton.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { Button } from "reactstrap";
+
+/**-------Props--------
+ * isSmall: dictates display of anything marked with className '.viewport-aware'
+ * ...    : any props you would pass to a reactstrap button
+ */
+const ViewportAwareButton = props => {
+  // eliminate viewport aware children if small.
+  let { children, ...remainder } = props;
+  if (props.isSmall)
+    children = Array.from(props.children).filter(
+      child => child.props.className !== "viewport-aware",
+    );
+
+  return <Button children={children} {...remainder} />;
+};
+
+export default ViewportAwareButton;

--- a/src/components/Editor/components/ViewportAwareButton.js
+++ b/src/components/Editor/components/ViewportAwareButton.js
@@ -10,7 +10,7 @@ const ViewportAwareButton = props => {
   let { children, ...remainder } = props;
   if (props.isSmall)
     children = Array.from(props.children).filter(
-      child => child.props.className !== "viewport-aware",
+      child => !child.props.className.split(" ").includes("viewport-aware"),
     );
 
   return <Button children={children} {...remainder} />;

--- a/src/components/Editor/components/ViewportAwareButton.js
+++ b/src/components/Editor/components/ViewportAwareButton.js
@@ -2,18 +2,25 @@ import React from "react";
 import { Button } from "reactstrap";
 
 /**-------Props--------
- * isSmall: dictates display of anything marked with className '.viewport-aware'
- * ...    : any props you would pass to a reactstrap button
+ * isSmall: dictates display of text field
+ * icon: desired icon (i.e. <FontAwesomeIcon icon={...} />)
+ * text: the text label for the button
+ */
+/**--------Optional props--------
+ * any props you would apply to a reactstrap Button.
  */
 const ViewportAwareButton = props => {
-  // eliminate viewport aware children if small.
-  let { children, ...remainder } = props;
-  if (props.isSmall)
-    children = Array.from(props.children).filter(
-      child => !child.props.className.split(" ").includes("viewport-aware"),
-    );
+  // extract icon and text from props.
+  let { icon, text, ...remainder } = props;
 
-  return <Button children={children} {...remainder} />;
+  // render icon always, text only if not small.
+  return (
+    <Button {...remainder}>
+      {icon}
+
+      {!props.isSmall && <span className="viewport-aware-button-text">&nbsp;&nbsp;{text}</span>}
+    </Button>
+  );
 };
 
 export default ViewportAwareButton;

--- a/src/components/Editor/components/ViewportAwareButton.test.js
+++ b/src/components/Editor/components/ViewportAwareButton.test.js
@@ -5,26 +5,12 @@ import ViewportAwareButton from "./ViewportAwareButton";
 
 describe("<ViewportAwareButton />", () => {
   it("renders all children when normal sized.", () => {
-    let component = shallow(
-      <ViewportAwareButton isSmall={false}>
-        <span className="classA viewport-aware" />
-        <span className="classB" />
-      </ViewportAwareButton>,
-    );
-
-    expect(component.find(".classB").length).toBe(1);
-    expect(component.find(".viewport-aware").length).toBe(1);
+    let component = shallow(<ViewportAwareButton isSmall={false} icon={<div />} text="hi" />);
+    expect(component.find("span") && component.find("div"));
   });
 
   it("doesn't render viewport-aware children when small.", () => {
-    let component = shallow(
-      <ViewportAwareButton isSmall={true}>
-        <span className="classA viewport-aware" />
-        <span className="classB" />
-      </ViewportAwareButton>,
-    );
-
-    expect(component.find(".classB").length).toBe(1);
-    expect(component.find(".viewport-aware").length).toBe(0);
+    let component = shallow(<ViewportAwareButton isSmall={true} icon={<div />} text="hi" />);
+    expect(!component.find("span") && component.find("div"));
   });
 });

--- a/src/components/Editor/components/ViewportAwareButton.test.js
+++ b/src/components/Editor/components/ViewportAwareButton.test.js
@@ -7,24 +7,24 @@ describe("<ViewportAwareButton />", () => {
   it("renders all children when normal sized.", () => {
     let component = shallow(
       <ViewportAwareButton isSmall={false}>
-        <span className="viewport-aware" />
-        <span className="other" />
+        <span className="classA viewport-aware" />
+        <span className="classB" />
       </ViewportAwareButton>,
     );
 
-    expect(component.find(".other").length).toBe(1);
+    expect(component.find(".classB").length).toBe(1);
     expect(component.find(".viewport-aware").length).toBe(1);
   });
 
   it("doesn't render viewport-aware children when small.", () => {
     let component = shallow(
       <ViewportAwareButton isSmall={true}>
-        <span className="viewport-aware" />
-        <span className="other" />
+        <span className="classA viewport-aware" />
+        <span className="classB" />
       </ViewportAwareButton>,
     );
 
-    expect(component.find(".other").length).toBe(1);
+    expect(component.find(".classB").length).toBe(1);
     expect(component.find(".viewport-aware").length).toBe(0);
   });
 });

--- a/src/components/Editor/components/ViewportAwareButton.test.js
+++ b/src/components/Editor/components/ViewportAwareButton.test.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import ViewportAwareButton from "./ViewportAwareButton";
+
+describe("<ViewportAwareButton />", () => {
+  it("renders all children when normal sized.", () => {
+    let component = shallow(
+      <ViewportAwareButton isSmall={false}>
+        <span className="viewport-aware" />
+        <span className="other" />
+      </ViewportAwareButton>,
+    );
+
+    expect(component.find(".other").length).toBe(1);
+    expect(component.find(".viewport-aware").length).toBe(1);
+  });
+
+  it("doesn't render viewport-aware children when small.", () => {
+    let component = shallow(
+      <ViewportAwareButton isSmall={true}>
+        <span className="viewport-aware" />
+        <span className="other" />
+      </ViewportAwareButton>,
+    );
+
+    expect(component.find(".other").length).toBe(1);
+    expect(component.find(".viewport-aware").length).toBe(0);
+  });
+});

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -139,12 +139,9 @@ class Editor extends React.Component {
           size="lg"
           onClick={this.handleSave}
           isSmall={this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT}
-        >
-          <FontAwesomeIcon icon={faSave} />
-          <span className="editor-button-text viewport-aware">
-            &nbsp;&nbsp;{this.state.saveText}
-          </span>
-        </ViewportAwareButton>
+          icon={<FontAwesomeIcon icon={faSave} />}
+          text={this.state.saveText}
+        />
 
         <Button className="mx-2" color="success" size="lg" onClick={this.handleDownload}>
           <FontAwesomeIcon icon={faDownload} />

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -34,6 +34,7 @@ class Editor extends React.Component {
     super(props);
     this.state = {
       saveText: "Save",
+      isSmall: this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT,
       viewMode: this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT ? CODE_ONLY : CODE_AND_OUTPUT,
       redirect: this.props.listOfPrograms.length === 0 ? "/sketches" : "",
       pane1Style: { transition: "width .5s ease" },
@@ -44,10 +45,11 @@ class Editor extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.screenWidth !== prevProps.screenWidth) {
       if (this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT) {
+        this.setState({ isSmall: true });
         if (this.state.viewMode === CODE_AND_OUTPUT) {
           this.setState({ viewMode: CODE_ONLY });
         }
-      }
+      } else this.setState({ isSmall: false });
     }
   }
 
@@ -130,7 +132,7 @@ class Editor extends React.Component {
           <EditorRadio
             viewMode={this.state.viewMode}
             updateViewMode={this.updateViewMode}
-            isSmall={this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT}
+            isSmall={this.state.isSmall}
           />
         </div>
         <ViewportAwareButton
@@ -138,7 +140,7 @@ class Editor extends React.Component {
           color="success"
           size="lg"
           onClick={this.handleSave}
-          isSmall={this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT}
+          isSmall={this.state.isSmall}
         >
           <FontAwesomeIcon icon={faSave} />
           <span className="editor-button-text viewport-aware">
@@ -167,7 +169,7 @@ class Editor extends React.Component {
     <OutputContainer
       viewMode={this.state.viewMode}
       updateViewMode={this.updateViewMode}
-      isSmall={this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT}
+      isSmall={this.props.isSmall}
     />
   );
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import SplitPane from "react-split-pane";
 import { Button } from "reactstrap";
+import ViewportAwareButton from "./components/ViewportAwareButton.js";
 import OutputContainer from "./containers/OutputContainer.js";
 import TextEditorContainer from "./containers/TextEditorContainer";
 import DropdownButtonContainer from "./containers/DropdownButtonContainer";
@@ -33,8 +34,8 @@ class Editor extends React.Component {
     super(props);
     this.state = {
       saveText: "Save",
-      viewMode: (this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT) ? CODE_ONLY : CODE_AND_OUTPUT,
-      redirect: (this.props.listOfPrograms.length === 0) ? "/sketches" : "",
+      viewMode: this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT ? CODE_ONLY : CODE_AND_OUTPUT,
+      redirect: this.props.listOfPrograms.length === 0 ? "/sketches" : "",
       pane1Style: { transition: "width .5s ease" },
     };
   }
@@ -132,12 +133,18 @@ class Editor extends React.Component {
             isSmall={this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT}
           />
         </div>
-        <Button className="mx-2" color="success" size="lg" onClick={this.handleSave}>
+        <ViewportAwareButton
+          className="mx-2"
+          color="success"
+          size="lg"
+          onClick={this.handleSave}
+          isSmall={this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT}
+        >
           <FontAwesomeIcon icon={faSave} />
-          {this.props.screenWidth > EDITOR_WIDTH_BREAKPOINT && (
-            <span className="editor-button-text">&nbsp;&nbsp;{this.state.saveText}</span>
-          )}
-        </Button>
+          <span className="editor-button-text viewport-aware">
+            &nbsp;&nbsp;{this.state.saveText}
+          </span>
+        </ViewportAwareButton>
 
         <Button className="mx-2" color="success" size="lg" onClick={this.handleDownload}>
           <FontAwesomeIcon icon={faDownload} />

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -34,7 +34,6 @@ class Editor extends React.Component {
     super(props);
     this.state = {
       saveText: "Save",
-      isSmall: this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT,
       viewMode: this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT ? CODE_ONLY : CODE_AND_OUTPUT,
       redirect: this.props.listOfPrograms.length === 0 ? "/sketches" : "",
       pane1Style: { transition: "width .5s ease" },
@@ -45,11 +44,10 @@ class Editor extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.screenWidth !== prevProps.screenWidth) {
       if (this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT) {
-        this.setState({ isSmall: true });
         if (this.state.viewMode === CODE_AND_OUTPUT) {
           this.setState({ viewMode: CODE_ONLY });
         }
-      } else this.setState({ isSmall: false });
+      }
     }
   }
 
@@ -132,7 +130,7 @@ class Editor extends React.Component {
           <EditorRadio
             viewMode={this.state.viewMode}
             updateViewMode={this.updateViewMode}
-            isSmall={this.state.isSmall}
+            isSmall={this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT}
           />
         </div>
         <ViewportAwareButton
@@ -140,7 +138,7 @@ class Editor extends React.Component {
           color="success"
           size="lg"
           onClick={this.handleSave}
-          isSmall={this.state.isSmall}
+          isSmall={this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT}
         >
           <FontAwesomeIcon icon={faSave} />
           <span className="editor-button-text viewport-aware">
@@ -169,7 +167,7 @@ class Editor extends React.Component {
     <OutputContainer
       viewMode={this.state.viewMode}
       updateViewMode={this.updateViewMode}
-      isSmall={this.props.isSmall}
+      isSmall={this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT}
     />
   );
 


### PR DESCRIPTION
Hey there. Remember on Friday when we were trying to figure out how to test my fix from earlier? Well, I made this to make the testing easier. This pull request adds the following:

* `ViewportAwareButton`
    - Works just like a reactstrap `Button`, but removes any children marked with the class `viewport-aware` when given the prop `isSmall`.
* Tests for `ViewportAwareButton`
    - With the above out of the way, testing is rather straightforward.