### PR TITLE
Fix Pill Logic w/ Small "Output"-only View

### DIFF
--- a/src/components/Editor/components/Output.js
+++ b/src/components/Editor/components/Output.js
@@ -41,6 +41,10 @@ class Output extends React.Component {
       return true;
     }
 
+    if (this.props.isSmall !== nextProps.isSmall) {
+      return true;
+    }
+
     if (
       this.state.run !== nextState.run ||
       this.state.counter !== nextState.counter ||


### PR DESCRIPTION
- Fix bug where pill won't update to hide 'both' option when screen gets too small on output mode and won't update to show 'both' option when screen gets big enough on output mode.

- Solution: added a check so that component updates if screen size passes the "small" threshold