### PR TITLE
Removes Unused Configuration Files

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-    "presets": [ "react", "es2016", "env"],
-    "plugins": ["emotion"]
-}

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,0 @@
-{
-  "projects": {
-    "default": "teachlacodingplatform"
-  }
-}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,0 @@
-JS_FILES := $(shell find . -name "*.js" -not -path "./node_modules/*")
-
-format:
-	@./node_modules/.bin/prettier --write $(JS_FILES)


### PR DESCRIPTION
* we don't use `babel` manually (it's done through CRA), so we don't need `.babelrc`
* we don't deploy to firebase (anymore), so we don't need `.firebaserc`
* now that `lint-staged` applies `prettier` already, we don't need `make format`