### PR TITLE
Added help text to loading page

### DIFF
--- a/src/components/common/LoadingPage.js
+++ b/src/components/common/LoadingPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { RingLoader } from "react-spinners";
 import "styles/Loading.scss";
 
@@ -10,29 +10,38 @@ import "styles/Loading.scss";
 		textPadding: string representing padding to the left of the text, i.e. distance from the img (give px units)
 */
 
-const Loading = props => {
-  const [showText, setShowText] = useState(false);
-
-  const componentDidMount = () => {
-    setTimeout(() => {
-      setShowText(true);
+class Loading extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showText: false,
+      timer: 0,
+    };
+  }
+  componentDidMount = () => {
+    this.setState.timer = setTimeout(() => {
+      this.setState({ showText: true });
     }, 2000);
   };
 
-  componentDidMount();
+  componentWillUnmount = () => {
+    clearTimeout(this.setState.timer);
+  };
 
-  return (
-    <div className="Loading">
-      <div className="Loading-title">Loading</div>
-      <RingLoader color={"#171124"} size={250} loading={true} />
-      {showText && (
-        <h1>
-          Looks like loading is taking a bit long! If it takes too long, submit an issue on
-          <a href="https://github.com/uclaacm/TeachLAFrontend/issues"> github</a>.
-        </h1>
-      )}
-    </div>
-  );
-};
+  render = () => {
+    return (
+      <div className="Loading">
+        <div className="Loading-title">Loading</div>
+        <RingLoader color={"#171124"} size={250} loading={true} />
+        {this.state.showText && (
+          <p className="Loading-page-text" style={{ color: "white" }}>
+            Looks like loading is taking a bit long! If it takes too long, submit an issue on
+            <a href="https://github.com/uclaacm/TeachLAFrontend/issues"> Github</a>.
+          </p>
+        )}
+      </div>
+    );
+  };
+}
 
 export default Loading;

--- a/src/components/common/LoadingPage.js
+++ b/src/components/common/LoadingPage.js
@@ -35,8 +35,15 @@ class Loading extends React.Component {
         <RingLoader color={"#171124"} size={250} loading={true} />
         {this.state.showText && (
           <p className="Loading-page-text" style={{ color: "white" }}>
-            Looks like loading is taking a bit long! If it takes too long, submit an issue on
-            <a href="https://github.com/uclaacm/TeachLAFrontend/issues"> Github</a>.
+            Looks like loading is taking a bit long! If it takes too long, submit an issue on{" "}
+            <span> </span>
+            <a
+              href="https://github.com/uclaacm/TeachLAFrontend/issues"
+              className="Loading-link-text"
+            >
+              Github
+            </a>
+            .
           </p>
         )}
       </div>

--- a/src/components/common/LoadingPage.js
+++ b/src/components/common/LoadingPage.js
@@ -10,6 +10,30 @@ import "styles/Loading.scss";
 		textPadding: string representing padding to the left of the text, i.e. distance from the img (give px units)
 */
 
+class LoadText extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { showText: false };
+  }
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({ showText: true });
+    }, 2000);
+  }
+
+  render() {
+    return (
+      <div>
+        <h1>
+          Looks like loading is taking a bit long! If it takes too long, submit an issue on{" "}
+          <a href="https://github.com/uclaacm/TeachLAFrontend/issues">github</a>.
+        </h1>
+      </div>
+    );
+  }
+}
+
 const Loading = props => (
   <div className="Loading">
     <div className="Loading-title">Loading</div>

--- a/src/components/common/LoadingPage.js
+++ b/src/components/common/LoadingPage.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { RingLoader } from "react-spinners";
 import "styles/Loading.scss";
 
@@ -10,35 +10,29 @@ import "styles/Loading.scss";
 		textPadding: string representing padding to the left of the text, i.e. distance from the img (give px units)
 */
 
-class LoadText extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { showText: false };
-  }
+const Loading = props => {
+  const [showText, setShowText] = useState(false);
 
-  componentDidMount() {
+  const componentDidMount = () => {
     setTimeout(() => {
-      this.setState({ showText: true });
+      setShowText(true);
     }, 2000);
-  }
+  };
 
-  render() {
-    return (
-      <div>
+  componentDidMount();
+
+  return (
+    <div className="Loading">
+      <div className="Loading-title">Loading</div>
+      <RingLoader color={"#171124"} size={250} loading={true} />
+      {showText && (
         <h1>
-          Looks like loading is taking a bit long! If it takes too long, submit an issue on{" "}
-          <a href="https://github.com/uclaacm/TeachLAFrontend/issues">github</a>.
+          Looks like loading is taking a bit long! If it takes too long, submit an issue on
+          <a href="https://github.com/uclaacm/TeachLAFrontend/issues"> github</a>.
         </h1>
-      </div>
-    );
-  }
-}
-
-const Loading = props => (
-  <div className="Loading">
-    <div className="Loading-title">Loading</div>
-    <RingLoader color={"#171124"} size={250} loading={true} />
-  </div>
-);
+      )}
+    </div>
+  );
+};
 
 export default Loading;

--- a/src/styles/Loading.scss
+++ b/src/styles/Loading.scss
@@ -30,5 +30,5 @@
 }
 
 .Loading-link-text:hover {
-  color: green;
+  color: $teachla-green;
 }

--- a/src/styles/Loading.scss
+++ b/src/styles/Loading.scss
@@ -16,3 +16,19 @@
   font-family: $font-family-heading;
   color: $off-white;
 }
+
+.Loading-page-text {
+  color: $off-white;
+  margin-top: 3rem;
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+.Loading-link-text {
+  color: $off-white;
+  text-decoration: underline; 
+}
+
+.Loading-link-text:hover {
+  color: green;
+}


### PR DESCRIPTION
Added help text to loading page if loading takes more than 2 seconds. Allows users to submit issues to Github through a link on the loading page.