### PR TITLE
Fixing Redirect Loop in Main.js (and other small fixes)

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -2,14 +2,12 @@ import React from "react";
 import SplitPane from "react-split-pane";
 import OutputContainer from "./Output/OutputContainer.js";
 import TextEditorContainer from "./TextEditor/containers/TextEditorContainer.js";
-import DropdownButtonContainer from "./common/containers/DropdownButtonContainer";
 import * as fetch from "../lib/fetch.js";
 import * as cookies from "../lib/cookies.js";
 import SketchesPageContainer from "./Sketches/containers/SketchesContainer";
 import "styles/Main.scss";
 import ProfilePanelContainer from "./common/containers/ProfilePanelContainer";
 
-import { Redirect } from "react-router-dom";
 import { EDITOR_WIDTH_BREAKPOINT, CODE_AND_OUTPUT, CODE_ONLY, OUTPUT_ONLY } from "../constants";
 import CodeDownloader from "../util/languages/CodeDownloader";
 
@@ -33,7 +31,6 @@ class Main extends React.Component {
     this.state = {
       saveText: "Save",
       viewMode: this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT ? CODE_ONLY : CODE_AND_OUTPUT,
-      redirect: this.props.listOfPrograms.length === 0 ? "/sketches" : "",
       pane1Style: { transition: "width .5s ease" },
     };
 
@@ -90,17 +87,13 @@ class Main extends React.Component {
     CodeDownloader.download(this.props.name, this.props.language, this.props.code);
   };
 
-  renderDropdown = () => <DropdownButtonContainer />;
-
-  renderSketchesPage = () => <SketchesPageContainer />;
-
   renderContent = () => {
     switch (this.props.contentType) {
-      case "sketches":
-        return this.renderSketchesPage();
       case "editor":
-      default:
         return this.renderEditor();
+      case "sketches":
+      default:
+        return <SketchesPageContainer />;
     }
   };
 
@@ -179,10 +172,6 @@ class Main extends React.Component {
   };
 
   render() {
-    if (this.state.redirect) {
-      return <Redirect to={this.state.redirect} />;
-    }
-
     const codeStyle = {
       left: this.props.left || 0,
       width: this.props.screenWidth - (this.props.left || 0),

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Redirect } from "react-router-dom";
 import SplitPane from "react-split-pane";
 import OutputContainer from "./Output/OutputContainer.js";
 import TextEditorContainer from "./TextEditor/containers/TextEditorContainer.js";
@@ -172,6 +173,10 @@ class Main extends React.Component {
   };
 
   render() {
+    // this stops us from rendering editor with no sketches available
+    if (this.props.contentType === "editor" && this.props.listOfPrograms.length === 0) {
+      return <Redirect to={"/sketches"} />;
+    }
     const codeStyle = {
       left: this.props.left || 0,
       width: this.props.screenWidth - (this.props.left || 0),


### PR DESCRIPTION
This is a lightning-quick PR to fix a whitescreen issue that we didn't realize was happening; namely, if you had no sketches, you'd be stuck in an infinite whitescreen redirect on the `/sketches` route. This PR fixes that by adding a check on the current `contentType`, and moves the check out of the constructor and performing the check at `render`. It also removes some other unused code in the `Main.js` file.

Abbreviated changelog:
- fixes redirect loop to sketches by making sure to check the current `contentType`, moves it out of the constructor and state scope
- removes unused `renderDropdown()` and Dropdown import
- makes sketches the default `renderContent`
- removes redundant `renderSketchesPage()` function