### PR TITLE
Adds Tests for <Loading>'s Timer + Minor Improvements

### DIFF
--- a/src/components/common/LoadingPage.js
+++ b/src/components/common/LoadingPage.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { RingLoader } from "react-spinners";
 import "styles/Loading.scss";
-import { GH_REPO_NAME } from "../constants";
+import { GH_REPO_NAME } from "../../constants";
 
 /*
 	Props:
@@ -15,13 +15,13 @@ class Loading extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      showText: false,
+      showHelpText: !!this.props.showHelpText,
       timer: 0,
     };
   }
   componentDidMount = () => {
     this.setState.timer = setTimeout(() => {
-      this.setState({ showText: true });
+      this.setState({ showHelpText: true });
     }, 2000);
   };
 
@@ -34,7 +34,7 @@ class Loading extends React.Component {
       <div className="Loading">
         <div className="Loading-title">Loading</div>
         <RingLoader color={"#171124"} size={250} loading={true} />
-        {this.state.showText && (
+        {this.state.showHelpText && (
           <p className="Loading-page-text" style={{ color: "white" }}>
             Looks like loading is taking a bit long! If it takes too long, submit an issue on{" "}
             <span> </span>

--- a/src/components/common/LoadingPage.js
+++ b/src/components/common/LoadingPage.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { RingLoader } from "react-spinners";
 import "styles/Loading.scss";
+import { GH_REPO_NAME } from "../constants";
 
 /*
 	Props:
@@ -37,10 +38,7 @@ class Loading extends React.Component {
           <p className="Loading-page-text" style={{ color: "white" }}>
             Looks like loading is taking a bit long! If it takes too long, submit an issue on{" "}
             <span> </span>
-            <a
-              href="https://github.com/uclaacm/TeachLAFrontend/issues"
-              className="Loading-link-text"
-            >
+            <a href={`${GH_REPO_NAME}/issues`} className="Loading-link-text">
               Github
             </a>
             .

--- a/src/components/common/LoadingPage.test.js
+++ b/src/components/common/LoadingPage.test.js
@@ -13,4 +13,27 @@ describe("LoadingPage", () => {
 
     expect(component).toMatchSnapshot();
   });
+
+  it("should handle showHelpText prop properly", () => {
+    const component = shallow(<LoadingPage />);
+    expect(component).toMatchSnapshot();
+
+    const component_sht_false = shallow(<LoadingPage showHelpText={false} />);
+    expect(component_sht_false.find(".Loading-page-text").length).toBe(0);
+    expect(component_sht_false.state().showHelpText).toEqual(false);
+
+    const component_sht_true = shallow(<LoadingPage showHelpText={true} />);
+    expect(component_sht_true.find(".Loading-page-text").length).toBe(1);
+    expect(component_sht_true.state().showHelpText).toEqual(true);
+  });
+
+  it("shows the help text after 2 seconds", async () => {
+    // TODO - use mock timers instead? didn't work the first time we tried it :(
+    const component = shallow(<LoadingPage />);
+    expect(component.state().showHelpText).toEqual(false);
+    expect(component.find(".Loading-page-text").length).toBe(0);
+    await new Promise(r => setTimeout(r, 2000));
+    expect(component.state().showHelpText).toEqual(true);
+    expect(component.find(".Loading-page-text").length).toBe(1);
+  });
 });

--- a/src/components/common/__snapshots__/LoadingPage.test.js.snap
+++ b/src/components/common/__snapshots__/LoadingPage.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`LoadingPage should handle showHelpText prop properly 1`] = `
+<div
+  className="Loading"
+>
+  <div
+    className="Loading-title"
+  >
+    Loading
+  </div>
+  <Loader
+    color="#171124"
+    css=""
+    loading={true}
+    size={250}
+  />
+</div>
+`;
+
 exports[`LoadingPage should render correctly 1`] = `
 <div
   className="Loading"


### PR DESCRIPTION
This is a quick follow up to @rzlien's PR (#197) adding a help text timer to `<Loading>`. It does three things:

1. renames the prop `showText` to `showHelpText`, and makes it inherit the value from an optional prop
2. uses `GH_REPO_NAME` constant instead of hard link for repo
3. adds tests to check for `showHelpText` prop validity and to check that the timer works (i.e. on mount, the help text is not there, and then after 2s, the help text shows up)

Not super happy with how the timer test is written, since I wanted to use Jest's [mock timer calls](https://jestjs.io/docs/en/timer-mocks) - but I wasn't able to get them to work. 