### PR TITLE
Uses CodeDownloader Everywhere

### DIFF
--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -5,7 +5,7 @@ import CreateSketchModalContainer from "./containers/CreateSketchModalContainer"
 import EditSketchModalContainer from "./containers/EditSketchModalContainer";
 import OpenPanelButtonContainer from "../common/containers/OpenPanelButtonContainer";
 import { SketchThumbnailArray } from "./constants";
-import ProcessingConstructor from "../Output/Processing";
+import CodeDownloader from "../../util/languages/CodeDownloader";
 import "styles/Sketches.scss";
 
 import { Button } from "reactstrap";
@@ -35,33 +35,6 @@ class Sketches extends React.Component {
 
   getRandomSketchThumbnail = () => {
     return SketchThumbnailArray[Math.floor(Math.random() * SketchThumbnailArray.length)];
-  };
-
-  downloadSketchCode = (name, language, code) => {
-    let extension = ".";
-    switch (language) {
-      case "python":
-        extension += "py";
-        break;
-      case "processing": // this is because we construct the processing result as an HTML file. jank.
-      case "html":
-        extension += "html";
-        break;
-      default:
-        extension += "txt";
-    }
-    // taken from this: https://stackoverflow.com/questions/44656610/download-a-string-as-txt-file-in-react
-    const element = document.createElement("a");
-    let file;
-    if (language === "processing") {
-      file = new Blob([ProcessingConstructor(code, true)], { type: "text/plain" });
-    } else {
-      file = new Blob([code], { type: "text/plain" });
-    }
-    element.href = URL.createObjectURL(file);
-    element.download = name + extension;
-    document.body.appendChild(element); // Required for this to work in FireFox
-    element.click();
   };
 
   setCreateSketchModalOpen = val => {
@@ -159,7 +132,7 @@ class Sketches extends React.Component {
             this.setConfirmDeleteModalOpen(true, name, key);
           }}
           downloadFunc={() => {
-            this.downloadSketchCode(name, language, code);
+            CodeDownloader.download(name, language, code);
           }}
           editFunc={() => {
             this.setEditSketchModalOpen(


### PR DESCRIPTION
This is a very quick PR that should just be some code motion; @fan-matt had previously implemented CodeDownloader in #114, but we had not replaced all the previous functionality with it. This PR finally gets around to using the same exported library function on the `Sketches` page too.