### PR TITLE
Removing Defunct Code

### DIFF
--- a/src/components/Output/Output.js
+++ b/src/components/Output/Output.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { PYTHON, JAVASCRIPT, CPP, JAVA, HTML, PROCESSING } from "../../constants";
+import { PYTHON, HTML, PROCESSING } from "../../constants";
 import { OUTPUT_ONLY } from "../../constants";
 import EditorRadio from "../TextEditor/components/EditorRadio.js";
 import CreateProcessingDoc from "../Output/Processing";
@@ -102,9 +102,6 @@ class Output extends React.Component {
         runResult = btoa(runResult);
         srcDocFunc = () => CreatePythonDoc(runResult, showConsole);
         break;
-      case JAVA:
-      case JAVASCRIPT:
-      case CPP:
       case HTML:
       default:
         break;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -3,9 +3,7 @@
 const PYTHON = "python";
 const JAVASCRIPT = "javascript";
 const HTML = "html";
-const JAVA = "java";
 const PROCESSING = "processing";
-const CPP = "c++";
 
 const SUPPORTED_LANGUAGES = [PYTHON, JAVASCRIPT, HTML, PROCESSING];
 
@@ -21,12 +19,8 @@ SUPPORTED_LANGUAGES.forEach(lang => {
       return (CODEMIRROR_CONVERSIONS[lang] = "javascript");
     case HTML:
       return (CODEMIRROR_CONVERSIONS[lang] = "htmlmixed");
-    case JAVA:
-      return (CODEMIRROR_CONVERSIONS[lang] = "text/x-java");
     case PROCESSING:
       return (CODEMIRROR_CONVERSIONS[lang] = "javascript");
-    case CPP:
-      return (CODEMIRROR_CONVERSIONS[lang] = "text/x-csrc");
     default:
       console.error("SUPPORTED LANGUAGE WITH NO MODE");
   }
@@ -80,9 +74,7 @@ module.exports = {
   PYTHON,
   JAVASCRIPT,
   HTML,
-  JAVA,
   PROCESSING,
-  CPP,
 
   // photo names
   PHOTO_NAMES,

--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -1,9 +1,4 @@
-// import {auth.FacebookAuthProvider} from "firebase";
-import * as firebase from "firebase/app";
 import "firebase/auth";
-
-// export const provider = new auth.FacebookAuthProvider();
-export const provider = new firebase.auth.FacebookAuthProvider();
 
 let config = {
   apiKey: "AIzaSyD6a3Br7b52N2c6MjZTu1UU0ssf3ZwbfoA",

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,9 +1,12 @@
-import { CPP, JAVA, JAVASCRIPT, PYTHON, PROCESSING, HTML } from "./index.js";
+import { JAVASCRIPT, PYTHON, PROCESSING, HTML } from "./index.js";
+
+/**
+ * takes in a language enumerable "constant" and returns its associated string. returns the empty string by default
+ * @param {ENUM} lang
+ */
 
 export const languageToDisplay = lang => {
   switch (lang) {
-    case JAVA:
-      return "Java";
     case PYTHON:
       return "Python";
     case PROCESSING:
@@ -12,8 +15,6 @@ export const languageToDisplay = lang => {
       return "Javascript";
     case HTML:
       return "HTML";
-    case CPP:
-      return "C++";
     default:
       return "";
   }

--- a/src/lib/helpers.unit.test.js
+++ b/src/lib/helpers.unit.test.js
@@ -1,21 +1,10 @@
 // import {nameToMode} from './helpers.js'
-import {
-  LANGUAGE_MAP,
-  MODE_MAP,
-  CPLUS_PLUS,
-  JAVASCRIPT,
-  JAVA,
-  HTML,
-  PROCESSING,
-  PYTHON,
-  DEFAULT_MODE,
-} from "./index";
+import { MODE_MAP, JAVASCRIPT, HTML, PROCESSING, PYTHON, DEFAULT_MODE } from "./index";
 
 // testing nameToMode to ensure all possible languages return correct modes and incorrect
 // language name returns the default mode
 xit("nameToMode returns correct modes for all supported languages", () => {
   expect(nameToMode(PYTHON)).toBe(MODE_MAP[PYTHON]);
-  expect(nameToMode(JAVA)).toBe(MODE_MAP[JAVA]);
   expect(nameToMode(JAVASCRIPT)).toBe(MODE_MAP[JAVASCRIPT]);
   expect(nameToMode(HTML)).toBe(MODE_MAP[HTML]);
   expect(nameToMode(PROCESSING)).toBe(MODE_MAP[PROCESSING]);


### PR DESCRIPTION
We won't be supporting C++/Java any time soon, and we no longer use the Facebook Auth provider. Removes code references to all of these things.