### PR TITLE
View-Only: Fixes Redux State Corruption

### DIFF
--- a/src/components/ViewOnly.js
+++ b/src/components/ViewOnly.js
@@ -31,11 +31,25 @@ class ViewOnly extends React.Component {
       code: "",
       loaded: false,
       notfound: false,
+      originalCode: "",
     };
   }
 
   componentDidMount = async () => {
+    const { ok: okOriginal, sketch: original } = await fetch.getSketch(
+      this.props.mostRecentProgram,
+    );
     const { ok, sketch } = await fetch.getSketch(this.props.programid);
+
+    if (!okOriginal) {
+      this.setState({ notfound: true });
+      return;
+    }
+
+    this.setState({
+      originalCode: original.code,
+    });
+
     if (!ok) {
       this.setState({ notfound: true });
       return;
@@ -61,6 +75,10 @@ class ViewOnly extends React.Component {
       }
     }
   }
+
+  componentWillUnmount = () => {
+    this.props.setProgramCode(this.props.mostRecentProgram, this.state.originalCode);
+  };
 
   onThemeChange = () => {
     let newTheme = this.props.theme === "dark" ? "light" : "dark";

--- a/src/components/ViewOnly.js
+++ b/src/components/ViewOnly.js
@@ -33,22 +33,15 @@ class ViewOnly extends React.Component {
       notfound: false,
       originalCode: "",
     };
+    this.savePrevProgram = (this.props.uid !== "");
   }
 
   componentDidMount = async () => {
-    const { ok: okOriginal, sketch: original } = await fetch.getSketch(
-      this.props.mostRecentProgram,
-    );
-    const { ok, sketch } = await fetch.getSketch(this.props.programid);
-
-    if (!okOriginal) {
-      this.setState({ notfound: true });
-      return;
+    if (this.savePrevProgram){
+      await this.codeSaverHelper();
     }
 
-    this.setState({
-      originalCode: original.code,
-    });
+    const { ok, sketch } = await fetch.getSketch(this.props.programid);
 
     if (!ok) {
       this.setState({ notfound: true });
@@ -77,8 +70,25 @@ class ViewOnly extends React.Component {
   }
 
   componentWillUnmount = () => {
-    this.props.setProgramCode(this.props.mostRecentProgram, this.state.originalCode);
+    if (this.savePrevProgram){
+      this.props.setProgramCode(this.props.mostRecentProgram, this.state.originalCode);
+    }
   };
+
+  codeSaverHelper = async () => {
+    const { ok: okOriginal, sketch: original } = await fetch.getSketch(
+      this.props.mostRecentProgram,
+    );
+
+    if (!okOriginal) {
+      this.setState({ notfound: true });
+      return;
+    }
+
+    this.setState({
+      originalCode: original.code,
+    });
+  }
 
   onThemeChange = () => {
     let newTheme = this.props.theme === "dark" ? "light" : "dark";


### PR DESCRIPTION
PR Fix implemented by @jamieliu386:

The bug:
1. Open a sketch in view-only mode.
2. Go to the sketches page and try to download your most recently viewed sketch.
3. The sketch title and extension are as expected, but the code is the code from the view-only sketch.

This happens because the Redux state is corrupted with `mostRecentProgram`; this is a temporary bandaid that properly deals with the Redux state, but doesn't solve the core problem.

This PR fixes the bug by saving the original code for the most recently viewed program when View-Only is entered, and then restores it before the component unmounts.

@jamieliu386 and/or @krashanoff, I'd like to see if there's a quicker bandaid style fix for this - refactoring `mostRecentProgram` and our Redux user manager (i.e. clearing out the state when the user logs out, storing the right things in cookies, etc.) is likely out of scope for the View Only PR, but I'm concerned about the dependence on the lifecycle hook. 