### PR TITLE
Fixes Loading Page Timer Reference

### DIFF
--- a/src/components/common/LoadingPage.js
+++ b/src/components/common/LoadingPage.js
@@ -16,18 +16,18 @@ class Loading extends React.Component {
     super(props);
     this.state = {
       showHelpText: !!this.props.showHelpText,
-      timer: 0,
     };
+    this.timer = false;
   }
   componentDidMount = () => {
-    this.setState.timer = setTimeout(() => {
-      this.setState({ showHelpText: true });
+    this.timer = setTimeout(() => {
+		this.setState({ showHelpText: true });
     }, 2000);
-  };
+  }
 
   componentWillUnmount = () => {
-    clearTimeout(this.setState.timer);
-  };
+    clearTimeout(this.timer);
+  }
 
   render = () => {
     return (


### PR DESCRIPTION
As Leo gave his presentation with our code snippet, I realized that our code was not written the way it was intended.

Currently in `master`, we had namespaced our timer in `this.setState.timer` - not technically non-compiling code, but probably not what was intended. 

Instead, this PR moves the timer outside of state (since instantiating or re-calling the timer itself doesn't warrant a refresh), and moves it to a var called `this.timer`.

This should be a simple refactor that causes no functionality changes. We should test to verify this!