### PR TITLE
Add Share Sketch Button

### DIFF
--- a/src/components/TextEditor/components/ShareSketchModal.js
+++ b/src/components/TextEditor/components/ShareSketchModal.js
@@ -1,0 +1,62 @@
+import React from "react";
+import ReactModal from "react-modal";
+
+import { Button, Input, InputGroup, InputGroupAddon } from "reactstrap";
+
+import { faCopy } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import "styles/Modals.scss";
+
+/**
+ * ShareSketchModal is a full-screen modal that displays
+ * the current program's view-only route, which the user can manually
+ * copy or use the "Copy To Clipboard" Button
+ * @param {Boolean} showModal modal render state
+ * @param {Function} toggleModal function that toggles the modal's render state
+ * @param {String} shareUrl the URL to display/copy to clipboard
+ */
+class ShareSketchModal extends React.Component {
+  state = {
+    copyStatus: 'Hit "Copy to Clipboard"!',
+  };
+
+  initiateCopy = () => {
+    navigator.clipboard.writeText(this.props.shareUrl).then(
+      () => {
+        // success
+        this.setState({ copyStatus: "Successfully copied!" });
+      },
+      () => {
+        // failed
+        this.setState({ copyStatus: "Copy failed. If this keeps on happening, let us know!" });
+      },
+    );
+  };
+
+  render = () => {
+    return (
+      <ReactModal
+        className="modal-md"
+        overlayClassName="modal-overlay"
+        isOpen={this.props.showModal}
+        onRequestClose={this.props.toggleModal}
+        ariaHideApp={false}
+      >
+        <h2 className="text-center">Share This Sketch</h2>
+        <InputGroup>
+          <Input value={this.props.shareUrl} disabled />
+          <InputGroupAddon addonType="append">
+            <Button color="primary" onClick={this.initiateCopy}>
+              <FontAwesomeIcon icon={faCopy} /> Copy to Clipboard
+            </Button>
+          </InputGroupAddon>
+        </InputGroup>
+        <hr />
+        <p className="text-center">{this.state.copyStatus}</p>
+      </ReactModal>
+    );
+  };
+}
+
+export default ShareSketchModal;

--- a/src/components/TextEditor/components/TextEditor.js
+++ b/src/components/TextEditor/components/TextEditor.js
@@ -8,8 +8,7 @@ import OpenPanelButtonContainer from "../../common/containers/OpenPanelButtonCon
 import { EDITOR_WIDTH_BREAKPOINT } from "../../../constants";
 import ViewportAwareButton from "../../common/ViewportAwareButton.js";
 import DropdownButtonContainer from "../../common/containers/DropdownButtonContainer";
-import { faSave } from "@fortawesome/free-solid-svg-icons";
-import { faDownload } from "@fortawesome/free-solid-svg-icons";
+import { faDownload, faSave, faShare } from "@fortawesome/free-solid-svg-icons";
 import { SketchThumbnailArray } from "../../Sketches/constants";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -146,7 +145,17 @@ class TextEditor extends React.Component {
             text={this.props.saveText}
           />
         )}
-
+        {
+          <ViewportAwareButton
+            className="mx-2"
+            color="primary"
+            size="lg"
+            onClick={() => console.log("shared!")}
+            isSmall={this.props.screenWidth <= EDITOR_WIDTH_BREAKPOINT}
+            icon={<FontAwesomeIcon icon={faShare} />}
+            text={"Share"}
+          />
+        }
         {
           <Button className="mx-2" color="success" size="lg" onClick={this.props.handleDownload}>
             <FontAwesomeIcon icon={faDownload} />

--- a/src/components/TextEditor/components/TextEditor.js
+++ b/src/components/TextEditor/components/TextEditor.js
@@ -1,21 +1,20 @@
 import React from "react";
-import ReactModal from "react-modal";
 
 import { CODEMIRROR_CONVERSIONS } from "../../../constants";
 import * as fetch from "../../../lib/fetch.js";
 import sketch from "../../../lib/";
-import EditorRadio from "./EditorRadio.js";
 
-import { Button, Input, InputGroup, InputGroupAddon } from "reactstrap";
+import EditorRadio from "./EditorRadio.js";
+import ShareSketchModal from "./ShareSketchModal";
+
+import { Button } from "reactstrap";
 import OpenPanelButtonContainer from "../../common/containers/OpenPanelButtonContainer";
 import { EDITOR_WIDTH_BREAKPOINT } from "../../../constants";
 import ViewportAwareButton from "../../common/ViewportAwareButton.js";
 import DropdownButtonContainer from "../../common/containers/DropdownButtonContainer";
-import { faCopy, faDownload, faSave, faShare } from "@fortawesome/free-solid-svg-icons";
+import { faDownload, faSave, faShare } from "@fortawesome/free-solid-svg-icons";
 import { SketchThumbnailArray } from "../../Sketches/constants";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-
-import "styles/Modals.scss";
 
 let CodeMirror = null;
 if (typeof window !== "undefined" && typeof window.navigator !== "undefined") {
@@ -123,29 +122,6 @@ class TextEditor extends React.Component {
     }
   };
 
-  renderShareModal = () => {
-    const shareUrl = sketch.constructShareableSketchURL(this.props.mostRecentProgram);
-    return (
-      <ReactModal
-        className="modal-md"
-        overlayClassName="modal-overlay"
-        isOpen={this.state.showShareModal}
-        onRequestClose={this.toggleShareModal}
-        ariaHideApp={false}
-      >
-        <h2 className="text-center">Share This Sketch</h2>
-        <InputGroup>
-          <Input value={shareUrl} disabled />
-          <InputGroupAddon addonType="append">
-            <Button color="primary" onClick={() => navigator.clipboard.writeText(shareUrl)}>
-              <FontAwesomeIcon icon={faCopy} /> Copy to Clipboard
-            </Button>
-          </InputGroupAddon>
-        </InputGroup>
-      </ReactModal>
-    );
-  };
-
   renderDropdown = () => <DropdownButtonContainer />;
 
   renderSketchName = () => <div className="program-sketch-name">{this.props.sketchName}</div>;
@@ -213,7 +189,11 @@ class TextEditor extends React.Component {
       <div className={`theme-` + this.props.theme} style={{ height: "100%" }}>
         <div className="code-section">
           {this.renderBanner()}
-          {this.renderShareModal()}
+          <ShareSketchModal
+            shareUrl={sketch.constructShareableSketchURL(this.props.mostRecentProgram)}
+            showModal={this.state.showShareModal}
+            toggleModal={this.toggleShareModal}
+          />
           <div
             className="text-editor-container"
             style={{

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,9 +1,11 @@
 import * as cookies from "./cookies.js";
 import * as fetch from "./fetch.js";
 import * as helpers from "./fetch.js";
+import * as sketch from "./sketch.js";
 
 export default {
   ...cookies,
   ...fetch,
   ...helpers,
+  ...sketch,
 };

--- a/src/lib/sketch.js
+++ b/src/lib/sketch.js
@@ -4,16 +4,16 @@ import constants from "../constants";
  * constructShareableSketchURL: given a program ID, generate
  * a shareable link to the view-only version of that program.
  * checks for the current hostname using window.location.hostname,
- * and assumes HTTPS if not localhost
- * @param {String} programId
+ * @param {String} programId the id of the program
+ * @param {String} [domainRoot=window.location.hostname] domainRoot (e.g. editor.uclaacm.com). defaults localhost to 8080
  */
 
-export const constructShareableSketchURL = (programId) => {
+export const constructShareableSketchURL = (programId, domainRoot = window.location.hostname) => {
   let root;
-  if (window.location.hostname === "localhost") {
+  if (domainRoot.includes("localhost")) {
     root = "http://localhost:8080";
   } else {
-    root = `https://${window.location.hostname}`;
+    root = `https://${domainRoot}`;
   }
 
   return `${root}${constants.ROUTER_BASE_NAME}p/${programId}`;

--- a/src/lib/sketch.js
+++ b/src/lib/sketch.js
@@ -1,0 +1,20 @@
+import constants from "../constants";
+
+/**
+ * constructShareableSketchURL: given a program ID, generate
+ * a shareable link to the view-only version of that program.
+ * checks for the current hostname using window.location.hostname,
+ * and assumes HTTPS if not localhost
+ * @param {String} programId
+ */
+
+export const constructShareableSketchURL = (programId) => {
+  let root;
+  if (window.location.hostname === "localhost") {
+    root = "http://localhost:8080";
+  } else {
+    root = `https://${window.location.hostname}`;
+  }
+
+  return `${root}${constants.ROUTER_BASE_NAME}p/${programId}`;
+};

--- a/src/lib/sketch.test.js
+++ b/src/lib/sketch.test.js
@@ -1,0 +1,23 @@
+import { constructShareableSketchURL } from "./sketch";
+
+describe("constructShareableSketchURL", () => {
+  it("works with localhost", () => {
+    expect(constructShareableSketchURL("owo", "localhost")).toBe("http://localhost:8080/p/owo");
+  });
+  it("works with editor.uclaacm.com", () => {
+    expect(constructShareableSketchURL("owo", "editor.uclaacm.com")).toBe(
+      "https://editor.uclaacm.com/p/owo",
+    );
+  });
+  it("somewhat gracefully handles no parameters", () => {
+    expect(constructShareableSketchURL()).toBe("http://localhost:8080/p/undefined");
+  });
+  it("reads from window.location.hostname", () => {
+    delete global.window.location;
+    global.window = Object.create(window);
+    global.window.location = {
+      hostname: "not.a.real.domain",
+    };
+    expect(constructShareableSketchURL("owo")).toBe("https://not.a.real.domain/p/owo");
+  });
+});

--- a/src/styles/Modals.scss
+++ b/src/styles/Modals.scss
@@ -1,0 +1,33 @@
+.modal-sm {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 50%;
+    min-width: 400px;
+    background-color: rgb(255, 255, 255);
+    padding: 40px;
+    border-radius: 20px;
+} 
+
+.modal-md {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 50%;
+    min-width: 450px;
+    background-color: rgb(255, 255, 255);
+    padding: 40px;
+    border-radius: 20px;
+} 
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(59, 59, 59, 0.514);
+    z-index: 80;
+}


### PR DESCRIPTION
This PR adds a "Share Sketch" button in all `TextEditor`, which opens a modal (a new component called `ShareSketchModal`) that allows the user to view the view-only URL to the current program, as well as copy-to-clipboard with a convenient button. I also added a library file `sketch.js`, which has a function called `constructShareableSketchURL` that generates the proper URL based on the Sketch ID and environment parameters. Note that this feature works whether or not the user is logged in, and/or viewing their own sketch.

Changes:
* created new component, `ShareSketchModal` in `src/components/TextEditor/components`
* created new library file, `sketch.js` in `src/lib/`, with function `constructShareableSketchURL`
* wrote tests for `constructShareableSketchURL`
* created a "standard" `.scss` file for Modal styles, in `Modals.scss`
* added button to header of `TextEditor` to trigger the modal open

Things to note:
* To implement the copy-to-clipboard, I used the [`Clipboard.writeText()`](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText) library. Note that this has no IE support; I have not implemented a fall-back, but I do create an error message.
* I have not written any tests for `ShareSketchModal`. I think eventually we should do a modal standardization pass + a set of smoke tests we can use.
* I think the button header is pretty stacked already, and with fork coming soon it'll be more crowded. We should figure out some way to make it more compact (either a dropdown or smaller icons), but that's out of scope of this PR.