### PR TITLE
Fix Incorrect State Update in Sketch/index.js, Typo in Image Selector

### DIFF
--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -37,7 +37,7 @@ class Sketches extends React.Component {
     return SketchThumbnailArray[Math.floor(Math.random() * SketchThumbnailArray.length)];
   };
 
-  setCreateSketchModalOpen = val => {
+  setCreateSketchModalOpen = (val) => {
     this.setState({ createSketchModalOpen: val });
   };
 
@@ -55,7 +55,7 @@ class Sketches extends React.Component {
     });
   };
 
-  setProgram = name => {
+  setProgram = (name) => {
     this.props.setMostRecentProgram(name);
   };
 
@@ -74,7 +74,7 @@ class Sketches extends React.Component {
     </div>
   );
 
-  getThumbnailSrc = val => {
+  getThumbnailSrc = (val) => {
     if (val === undefined || val === "" || val >= SketchThumbnailArray.length || val < 0) {
       return SketchThumbnailArray[0];
     }
@@ -166,7 +166,7 @@ class Sketches extends React.Component {
   renderConfirmDeleteModal = () => (
     <ConfirmDeleteModalContainer
       isOpen={this.state.confirmDeleteModalOpen}
-      onClose={() => this.setConfirmDeleteModalOpen(false)}
+      onClose={() => this.setState({ confirmDeleteModalOpen: false })}
       sketchName={this.state.selectedSketch}
       sketchKey={this.state.selectedKey}
     />
@@ -175,14 +175,14 @@ class Sketches extends React.Component {
   renderCreateSketchModal = () => (
     <CreateSketchModalContainer
       isOpen={this.state.createSketchModalOpen}
-      onClose={() => this.setCreateSketchModalOpen(false)}
+      onClose={() => this.setState({ createSketchModalOpen: false })}
     />
   );
 
   renderEditSketchModal = () => (
     <EditSketchModalContainer
       isOpen={this.state.editSketchModalOpen}
-      onClose={() => this.setEditSketchModalOpen(false)}
+      onClose={() => this.setState({ editSketchModalOpen: false })}
       sketchName={this.state.selectedSketch}
       sketchImg={this.state.selectedImg}
       sketchLang={this.state.selectedLang}

--- a/src/components/common/ImageSelector.js
+++ b/src/components/common/ImageSelector.js
@@ -3,8 +3,8 @@ import ReactModal from "react-modal";
 import { Container } from "reactstrap";
 import "../../styles/ImageSelector.scss";
 class ImageSelector extends React.Component {
-  render(){
-    return(
+  render() {
+    return (
       <ReactModal
         isOpen={this.props.isOpen}
         onRequestClose={this.props.closeModal}
@@ -12,10 +12,12 @@ class ImageSelector extends React.Component {
         overlayClassName="profile-image-overlay"
         ariaHideApp={false}
       >
-        <Container style={{"max-width": `${this.props.maxWidth}px`,}}>
+        <Container style={{ maxWidth: `${this.props.maxWidth}px` }}>
           <div className=".image-selector-modal-header d-flex align-items-center">
             <h1>Choose a thumbnail</h1>
-            <div className="image-selector-modal-header-thumbnail-container">{this.props.thumbnailPreview || null}</div>
+            <div className="image-selector-modal-header-thumbnail-container">
+              {this.props.thumbnailPreview || null}
+            </div>
           </div>
           <hr />
           <div className="image-selector-gallery">{this.props.icons}</div>
@@ -25,8 +27,8 @@ class ImageSelector extends React.Component {
           {this.props.children} {/* Footer buttons as passed in as children */}
         </Container>
       </ReactModal>
-    )
-  } 
+    );
+  }
 }
 
 export default ImageSelector;


### PR DESCRIPTION
This PR addresses two bugs (and leaves a third unsolved, but slightly-better solved):

1. As @jamieliu386 reported, there is a bug involving controlled vs. uncontrolled inputs when the Create, Edit, or Delete Sketch modals are left. This is because previously, they (for some reason) updated the input values *in the modal* after they are closed, which is when the internals are unmounted by `react-modal`. I fixed this by... not doing that. This resolves the problem for `EditSketch` and `ConfirmDelete`, but there are lingering problems in `CreateSketch` (which I will not deal with in this PR).

2. There was a small typo involving `maxWidth` instead of `max-width` for a CSS-in-JS property in `ImageSelector`; this fixes that typo.

A general observation is that all of these modals are really really poorly coded and probably need an entire refactor. Slow and steady wins the race.