### PR TITLE
Fixes deleting mostRecentProgram in ConfirmDeleteModal

### DIFF
--- a/src/components/Sketches/components/ConfirmDeleteModal.js
+++ b/src/components/Sketches/components/ConfirmDeleteModal.js
@@ -19,10 +19,10 @@ class ConfirmDeleteModal extends React.Component {
     try {
       fetch
         .deleteSketch(data)
-        .then(res => {
+        .then((res) => {
           return res.json();
         })
-        .then(json => {
+        .then((json) => {
           if (!json.ok) {
             this.setState({
               spinner: false,
@@ -31,17 +31,30 @@ class ConfirmDeleteModal extends React.Component {
             return;
           }
           this.props.deleteProgram(this.props.sketchKey);
+
+          // this next piece of code is a guard against deleting mostRecentProgram - if we do,
+          // then we need to re-populate it with something different.
+          if (
+            this.props.sketchKey === this.props.mostRecentProgram &&
+            this.props.programKeys.size > 1
+          ) {
+            if (this.props.sketchKey === this.props.programKeys[0]) {
+              this.props.setMostRecentProgram(this.props.programKeys.get(1));
+            } else {
+              this.props.setMostRecentProgram(this.props.programKeys.get(0));
+            }
+          }
           this.closeModal();
         })
-        .catch(err => {
+        .catch((err) => {
           this.setState({
             spinner: false,
             error: "Failed to create sketch, please try again later",
           });
-          console.log(err);
+          console.error(err);
         });
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
     this.setState({ spinner: true, error: "" });
   };

--- a/src/components/Sketches/components/ConfirmDeleteModal.js
+++ b/src/components/Sketches/components/ConfirmDeleteModal.js
@@ -30,20 +30,18 @@ class ConfirmDeleteModal extends React.Component {
             });
             return;
           }
+
           this.props.deleteProgram(this.props.sketchKey);
 
           // this next piece of code is a guard against deleting mostRecentProgram - if we do,
           // then we need to re-populate it with something different.
           if (
             this.props.sketchKey === this.props.mostRecentProgram &&
-            this.props.programKeys.size > 1
+            this.props.programKeys.size > 0
           ) {
-            if (this.props.sketchKey === this.props.programKeys[0]) {
-              this.props.setMostRecentProgram(this.props.programKeys.get(1));
-            } else {
-              this.props.setMostRecentProgram(this.props.programKeys.get(0));
-            }
+            this.props.setMostRecentProgram(this.props.programKeys.get(0));
           }
+
           this.closeModal();
         })
         .catch((err) => {

--- a/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
+++ b/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
@@ -1,16 +1,22 @@
 import ConfirmDeleteModal from "../components/ConfirmDeleteModal.js";
 import { connect } from "react-redux";
 import { deleteProgram } from "../../../actions/programsActions";
+import { setMostRecentProgram } from "../../../actions/userDataActions.js";
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
+  const { mostRecentProgram, uid } = state.userData;
+  const programKeys = state.programs.keySeq(); // this is an immutable sequence
   return {
-    uid: state.userData.uid,
+    mostRecentProgram,
+    programKeys,
+    uid,
   };
 };
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     deleteProgram: (program, data) => dispatch(deleteProgram(program, data)),
+    setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
   };
 };
 


### PR DESCRIPTION
This PR fixes the nasty bug that corrupts our internal Redux state when you delete what happens to be the `mostRecentProgram`. We do this by adding a check when we delete the sketch: if the sketch's ID matches `mostRecentProgram`, we then update it with `setMostRecentProgram` with either the first item in the new programs list.

As a minor impl. note, we don't have to worry about a situation with only one sketch, as the editor component itself handles situations with zero sketches (and doesn't access mostRecentProgram). So, this fix doesn't change the existing bevhaiour in that scenario.

If we add more areas where we delete sketches (i.e. in the classes feature), we should probably make some action that does something to the effect of `deleteSketchAndUpdate` that handles all of these things at once, which reduces our cognitive load!

As an aside, we should probably check that `mostRecentProgram` is valid whenever we access it, and/or refactor many of its uses (as we've discussed, the editor depends too much on it).