### PR TITLE
Smaller "User Card" in Profile Panel

### DIFF
--- a/src/components/common/ProfilePanel.js
+++ b/src/components/common/ProfilePanel.js
@@ -25,7 +25,7 @@ import "styles/Panel.scss";
 import Switch from "./Switch";
 import Footer from "./Footer";
 
-import ImageSelector from "./ImageSelector"
+import ImageSelector from "./ImageSelector";
 /**--------Props--------
  * togglePanel: function to be called when the panel is collapsed or opened
  */
@@ -61,7 +61,7 @@ class ProfilePanel extends React.Component {
     this.setState({ showModal: true });
   };
 
-  onNameChange = e => {
+  onNameChange = (e) => {
     this.setState({ name: e.target.value });
   };
 
@@ -82,7 +82,7 @@ class ProfilePanel extends React.Component {
     return false;
   };
 
-  onNameSubmit = e => {
+  onNameSubmit = (e) => {
     e.preventDefault();
     let badInputs = this.checkInputs();
 
@@ -125,17 +125,17 @@ class ProfilePanel extends React.Component {
   renderPanelImage = () => {
     return (
       <div
-        className="panel-image-container"
+        className="panel-user-image-container"
         onMouseEnter={() => this.setState({ imageIsHovering: true })}
         onMouseLeave={() => this.setState({ imageIsHovering: false })}
       >
         <img
-          className="panel-image"
+          className="panel-user-image"
           src={PHOTO_NAMES[this.props.photoName] || PHOTO_NAMES[DEFAULT_PHOTO_NAME]} // needs to be edited to use profile image name
           alt="Your profile"
         />
         {this.state.imageIsHovering && (
-          <button className="image-edit-button" onClick={this.handleOpenModal}>
+          <button className="panel-user-image-edit-button" onClick={this.handleOpenModal}>
             <FontAwesomeIcon icon={faEdit} />
           </button>
         )}
@@ -143,15 +143,18 @@ class ProfilePanel extends React.Component {
     );
   };
 
-  onImageClick = name => {
-    this.setState({ selectedImage: name });
-  };
-
   renderImageModal = () => {
+    if (!this.props.uid) {
+      return null;
+    }
     let names = Object.keys(PHOTO_NAMES);
-    let icons = names.map(val => {
+    let icons = names.map((val) => {
       return (
-        <figure className="gallery-item" key={val} onClick={() => this.onImageClick(val)}>
+        <figure
+          className="gallery-item"
+          key={val}
+          onClick={() => this.setState({ selectedImage: val })}
+        >
           <img
             src={PHOTO_NAMES[val]}
             className={"gallery-img" + (this.state.selectedImage === val ? "-selected" : "")}
@@ -190,19 +193,19 @@ class ProfilePanel extends React.Component {
     if (!this.state.editingName) {
       return (
         <div
-          className="panel-name"
+          className="panel-user-name"
           onMouseEnter={() => this.setState({ nameIsHovering: true })}
           onMouseLeave={() => this.setState({ nameIsHovering: false })}
           onClick={this.handleEditNameClick}
         >
-          <div className="panel-name-text">{this.props.displayName || "Joe Bruin"}</div>
+          <span className="panel-user-name-text">{this.props.displayName || "Joe Bruin"}</span>
           {this.state.nameIsHovering && (
             <button className="edit-icon-image" onClick={this.handleEditNameClick}>
               <FontAwesomeIcon icon={faEdit} />
             </button>
           )}
           <div
-            className="submitted-icon-image"
+            className="panel-user-name-submittted-icon"
             style={{ opacity: +(this.state.nameSubmitted ? "1" : "0") }}
           >
             <FontAwesomeIcon icon={faCheckSquare} />
@@ -211,16 +214,40 @@ class ProfilePanel extends React.Component {
       );
     } else {
       return (
-        <form className="panel-edit-container" onSubmit={this.onNameSubmit}>
+        <form className="panel-user-name-edit-container" onSubmit={this.onNameSubmit}>
           <input
             autoFocus
-            className="panel-edit"
+            className="panel-user-name-edit"
             placeholder={this.props.displayName}
             onChange={this.onNameChange}
             value={this.state.name}
             onBlur={this.onNameSubmit}
           />
         </form>
+      );
+    }
+  };
+
+  renderUserInformation = () => {
+    if (this.props.uid) {
+      // there exists a user
+      return (
+        <div className="panel-user-card">
+          {this.renderPanelImage()}
+          {this.renderName()}
+        </div>
+      );
+    } else {
+      // no user, render default image and name
+      return (
+        <div className="panel-user-card">
+          <img
+            className="panel-user-image"
+            src={PHOTO_NAMES[DEFAULT_PHOTO_NAME]}
+            alt="Guest User Profile"
+          />
+          <div className="panel-user-name">Guest User</div>
+        </div>
       );
     }
   };
@@ -281,17 +308,19 @@ class ProfilePanel extends React.Component {
   };
 
   renderThemeSwitch = () => {
-    let onToggle = on => {
+    let onToggle = (on) => {
       this.props.onThemeChange(on ? "light" : "dark");
     };
 
     return (
-      <Switch
-        on={this.props.theme === "dark" ? true : false}
-        onToggle={onToggle}
-        onImg={<FontAwesomeIcon icon={faMoon} className="icon-dark" />}
-        offImg={<FontAwesomeIcon icon={faSun} className="icon-light" />}
-      />
+      <div className="panel-switch-container">
+        <Switch
+          on={this.props.theme === "dark" ? true : false}
+          onToggle={onToggle}
+          onImg={<FontAwesomeIcon icon={faMoon} className="icon-dark" />}
+          offImg={<FontAwesomeIcon icon={faSun} className="icon-light" />}
+        />
+      </div>
     );
   };
 
@@ -321,6 +350,7 @@ class ProfilePanel extends React.Component {
 
   renderLoggedOutContent = () => (
     <div className="panel-content">
+      {this.renderUserInformation()}
       <div className="panel-buttons">
         {this.renderLoginButton()}
         {this.renderCreateUserButton()}
@@ -331,9 +361,7 @@ class ProfilePanel extends React.Component {
 
   renderContent = () => (
     <div className="panel-content">
-      {this.renderPanelImage()}
-      {this.renderImageModal()}
-      {this.renderName()}
+      {this.renderUserInformation()}
       {this.renderErrorMessage(this.state.displayNameMessage)}
       {this.renderButtons()}
       {this.renderThemeSwitch()}
@@ -357,6 +385,7 @@ class ProfilePanel extends React.Component {
         {this.renderCollapseButton()}
         {this.props.uid ? this.renderContent() : this.renderLoggedOutContent()}
         <Footer />
+        {this.renderImageModal()}
       </div>
     );
   }

--- a/src/components/common/ProfilePanel.test.js
+++ b/src/components/common/ProfilePanel.test.js
@@ -12,19 +12,21 @@ describe("ProfilePanel", () => {
 
   it("handles displayName prop properly", () => {
     const component = shallow(<ProfilePanel uid={"foo"} displayName={"Mark"} />);
-    expect(component.find(".panel-name-text").text()).toEqual("Mark");
+    expect(component.find(".panel-user-name-text").text()).toEqual("Mark");
 
     const component2 = shallow(<ProfilePanel uid={"foo"} />);
-    expect(component2.find(".panel-name-text").text()).toEqual("Joe Bruin");
+    expect(component2.find(".panel-user-name-text").text()).toEqual("Joe Bruin");
   });
 
   it("handles photoName prop properly", () => {
     const component = shallow(<ProfilePanel uid={"foo"} />);
-    expect(component.find(".panel-image").get(0).props.src).toBe(PHOTO_NAMES[DEFAULT_PHOTO_NAME]);
+    expect(component.find(".panel-user-image").get(0).props.src).toBe(
+      PHOTO_NAMES[DEFAULT_PHOTO_NAME],
+    );
 
     const name = Object.keys(PHOTO_NAMES)[1];
     const component2 = shallow(<ProfilePanel uid={"foo"} photoName={name} />);
-    expect(component2.find(".panel-image").get(0).props.src).toBe(PHOTO_NAMES[name]);
+    expect(component2.find(".panel-user-image").get(0).props.src).toBe(PHOTO_NAMES[name]);
   });
 
   it("Buttons change based on content type", () => {
@@ -57,29 +59,33 @@ describe("ProfilePanel", () => {
   it("handles displayName prop properly", () => {
     const component = shallow(<ProfilePanel uid={"foo"} />);
 
-    expect(component.find(".panel-image").get(0).props.src).toBe(PHOTO_NAMES[DEFAULT_PHOTO_NAME]);
+    expect(component.find(".panel-user-image").get(0).props.src).toBe(
+      PHOTO_NAMES[DEFAULT_PHOTO_NAME],
+    );
 
     const name = Object.keys(PHOTO_NAMES)[1];
     const component2 = shallow(<ProfilePanel uid={"foo"} photoName={name} />);
 
-    expect(component2.find(".panel-image").get(0).props.src).toBe(PHOTO_NAMES[name]);
+    expect(component2.find(".panel-user-image").get(0).props.src).toBe(PHOTO_NAMES[name]);
   });
 
   it("changing the panel image works", () => {
-    const clickFn = jest.fn(photo => photo);
+    const clickFn = jest.fn((photo) => photo);
     const component = shallow(<ProfilePanel uid={"foo"} setPhotoName={clickFn} />);
 
-    expect(component.find(".panel-image").get(0).props.src).toBe(PHOTO_NAMES[DEFAULT_PHOTO_NAME]);
+    expect(component.find(".panel-user-image").get(0).props.src).toBe(
+      PHOTO_NAMES[DEFAULT_PHOTO_NAME],
+    );
 
     //hover over the panel image
     expect(component.state().imageIsHovering).toBe(false);
-    component.find(".panel-image-container").simulate("mouseenter");
+    component.find(".panel-user-image-container").simulate("mouseenter");
     expect(component.state().imageIsHovering).toBe(true);
 
     //click the pencil icon (opens modal)
     expect(component.state().showModal).toBe(false);
     expect(component.find(".image-selector").prop("isOpen")).toEqual(false);
-    component.find(".image-edit-button").simulate("click");
+    component.find(".panel-user-image-edit-button").simulate("click");
     expect(component.state().showModal).toBe(true);
     expect(component.find(".image-selector").prop("isOpen")).toEqual(true);
 
@@ -98,42 +104,44 @@ describe("ProfilePanel", () => {
 
     //unhover the panel image
     expect(component.state().imageIsHovering).toBe(true);
-    component.find(".panel-image-container").simulate("mouseleave");
+    component.find(".panel-user-image-container").simulate("mouseleave");
     expect(component.state().imageIsHovering).toBe(false);
   });
 
   it("changing the display name works", () => {
-    const clickFn = jest.fn(name => name);
+    const clickFn = jest.fn((name) => name);
     const component = shallow(
       <ProfilePanel uid={"foo"} displayName={"Mark"} setDisplayName={clickFn} />,
     );
 
-    expect(component.find(".panel-name-text").text()).toBe("Mark");
+    expect(component.find(".panel-user-name-text").text()).toBe("Mark");
 
     //hover over the panel name
     expect(component.state().nameIsHovering).toBe(false);
-    component.find(".panel-name").simulate("mouseenter");
+    component.find(".panel-user-name").simulate("mouseenter");
     expect(component.state().nameIsHovering).toBe(true);
 
     //click the pencil icon (changes to input)
     expect(component.state().editingName).toBe(false);
     component.find(".edit-icon-image").simulate("click");
     expect(component.state().editingName).toBe(true);
-    expect(component.find(".panel-edit-container").length).toBe(1);
+    expect(component.find(".panel-user-name-edit-container").length).toBe(1);
 
     //check the input value starts as 'Mark', type in the input 'Not Mark', check that the input value and state changes to 'Not Mark'
     expect(component.state().name).toBe("Mark");
-    expect(component.find(".panel-edit").props().value).toBe("Mark");
-    component.find(".panel-edit").simulate("change", {
+    expect(component.find(".panel-user-name-edit").props().value).toBe("Mark");
+    component.find(".panel-user-name-edit").simulate("change", {
       target: {
         value: "Not Mark",
       },
     });
-    expect(component.find(".panel-edit").props().value).toBe("Not Mark");
+    expect(component.find(".panel-user-name-edit").props().value).toBe("Not Mark");
     expect(component.state().name).toBe("Not Mark");
 
     //submit change
-    component.find(".panel-edit-container").simulate("submit", { preventDefault: () => {} });
+    component
+      .find(".panel-user-name-edit-container")
+      .simulate("submit", { preventDefault: () => {} });
     expect(component.state().showModal).toBe(false);
     expect(clickFn.mock.calls[0][0] == "Not Mark");
     expect(component.state().name).toBe("Not Mark");
@@ -142,7 +150,7 @@ describe("ProfilePanel", () => {
 
     //unhover the panel name
     expect(component.state().nameIsHovering).toBe(true);
-    component.find(".panel-name").simulate("mouseleave");
+    component.find(".panel-user-name").simulate("mouseleave");
     expect(component.state().nameIsHovering).toBe(false);
   });
 

--- a/src/styles/ImageSelector.scss
+++ b/src/styles/ImageSelector.scss
@@ -29,7 +29,7 @@
   flex-wrap: wrap;
   overflow-y: auto;
   width: 100%;
-  height: 250px;
+  height: 300px;
   margin-left: 10px;
   margin-bottom: 10px;
 }

--- a/src/styles/Panel.scss
+++ b/src/styles/Panel.scss
@@ -4,9 +4,7 @@
   display: flex;
   position: absolute;
   flex-direction: column;
-  align-items: center;
   justify-content: flex-start;
-  box-sizing: content-box;
   margin: 0;
   padding: 0;
   transition: left 0.5s ease;
@@ -33,18 +31,11 @@
 .panel-content {
   display: flex;
   width: 100%;
+  padding: 1em;
   flex-direction: column;
-  align-items: center;
   justify-content: flex-start;
   overflow-y: auto;
   overflow-x: hidden;
-  box-sizing: content-box;
-}
-
-.panel-image {
-  width: 205px;
-  height: 200px;
-  /*background:#000;*/ /*if you leave this out, transparent profile pictures will show the background behind it*/
 }
 
 .profile-image-modal {
@@ -69,19 +60,50 @@
   z-index: 80;
 }
 
-.panel-image-container {
-  position: relative;
-  width: 205px;
-  height: 200px;
+.panel-user-card{
+  display: flex;
+  justify-content: flex-start;
 }
 
-.image-edit-button {
+.panel-user-image{
+  width: 60px;
+  height: 60px;
+}
+
+.panel-user-image-container {
+  width: 60px;
+  height: 60px;
+  :hover {
+    cursor: pointer;
+  }
+  position: relative;
+}
+
+.panel-user-name{
+  display: flex;
+  align-items: center;
+  padding-left: 1rem;
+  font-weight: bold;
+  font-size: 1.5rem;
+  position: relative;
+  :hover {
+    cursor: pointer;
+  }
+}
+
+.panel-switch-container{
+  display: flex;
+  justify-content: center;
+}
+
+.panel-user-image-edit-button {
   font-size: 1.25rem;
   border: none;
   background-color: transparent;
   position: absolute;
   right: -15px;
   bottom: -5px;
+  z-index: 100;
   @include themify($themes) {
     color: themed("accentColor");
   }
@@ -136,38 +158,34 @@
   }
   position: absolute;
   border: none;
-  right: -30px;
+  right: -40px;
   top: 50%;
   margin-top: -15px;
   background-color: transparent;
 }
 
-.submitted-icon-image {
-  font-size: 1.4rem;
+.panel-user-name-submittted-icon {
+  font-size: 1.25rem;
   color: $teachla-green;
   position: absolute;
-  float: left;
   border: none;
-  left: -20px;
+  right: -50px;
   top: 50%;
-  margin-top: -13px;
+  margin-top: -15px;
   background-color: transparent;
   transition: 0.5s;
 }
 
-.panel-edit-container {
+.panel-user-name-edit-container {
   display: flex;
-  flex-direction: column;
-  width: 100%;
   align-items: center;
+  padding-left: 1rem;
 }
 
-.panel-edit {
+.panel-user-name-edit {
   width: 90%;
-  float: middle;
   padding: 20px 0 5px;
-  text-align: center;
-  font-size: 2rem;
+  font-size: 1.5rem;
   word-wrap: break-word;
   background: none;
   align-items: baseline;
@@ -187,27 +205,8 @@
   padding: 0px 25px;
 }
 
-.panel-name {
-  float: middle;
-  text-align: center;
-  margin: 10px 50px 0px;
-  width: 70%;
-  padding: 10px 0 6px;
-  font-size: 2rem;
-  word-wrap: break-word;
-  @include themify($themes) {
-    color: themed("accentColor");
-  }
-  position: relative;
-  font-family: $font-family-heading;
-}
-
-.panel-name:hover {
-  cursor: pointer;
-}
-
 .panel-buttons {
-  width: 90%;
+  width: 100%;
   margin-left: auto;
   margin-right: auto;
   justify-content: flex-start;


### PR DESCRIPTION
Draft PR; goal is to make a smaller user card (i.e. the user image + name), as the current one probably takes up a bit too much space. Also includes some general profile panel refactoring.

This should tie directly into then changing the navigation in the profile panel to be more condensed (and therefore support more navigation options).