### PR TITLE
Add test-coverage script

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,7 +3,7 @@
   "plugins": [
     "stylelint-scss"
   ],
-  "ignoreFiles": ["**/*.ts", "**/*.tsx", "dist/*", "node_modules/*"],
+  "ignoreFiles": ["**/*.ts", "**/*.tsx", "dist/*", "node_modules/*", "coverage/*"],
   "rules": {
     "at-rule-no-unknown": null,
     "scss/at-rule-no-unknown": true

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
+    "test-coverage": "react-scripts test --env=jsdom --coverage --watchAll",
     "eject": "react-scripts eject",
     "dev": "concurrently --kill-others-on-fail \"yarn start\" \"yarn server\"",
     "lint-css": "stylelint \"**/*.css\" \"**/*.scss\"",
@@ -60,6 +61,20 @@
     }
   },
   "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx,ts,tsx}"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 90,
+        "functions": 90,
+        "lines": 90,
+        "statements": 90
+      }
+    },
+    "coverageReporters": [
+      "text"
+    ],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ]


### PR DESCRIPTION
Adds a test-coverage npm script, which also outputs the test coverage in a nice table. Obviously, tests won't appear super fast but it's something to slowly work towards.