### PR TITLE
switches CI action to use 16.x as latest node version

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 15.x]
+        node-version: [14.x, 16.x]
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Self-explanatory 😄 

~~edit: guess not, needs some work~~

merging in the `node-sass` -> `sass` change fixed it!