### PR TITLE
Allow lint errors to be committed; remove eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -126,5 +126,8 @@ module.exports = {
 
     // For loops are ok
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
+
+    // AirBNB changed this to only allow function-expressions
+    'react/function-component-definition': 'off',
   },
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "staging_start": "cross-env REACT_APP_FS_PROJ=staging REACT_APP_SERVER_TYPE=staging react-scripts start",
     "staging_build": "cross-env REACT_APP_FS_PROJ=staging REACT_APP_SERVER_TYPE=staging react-scripts build",
     "prepare": "husky install",
-    "pre-commit": "lint-staged",
+    "pre-commit": "lint-staged; exit 0",
     "prod_start": "cross-env REACT_APP_FS_PROJ=prod REACT_APP_SERVER_TYPE=prod react-scripts start",
     "prod_build": "cross-env REACT_APP_FS_PROJ=prod REACT_APP_SERVER_TYPE=prod react-scripts build"
   },


### PR DESCRIPTION
- Still runs lint on commit, but doesn't prevent commits on errors
- Remove the functional component rule

Note:
<img width="672" alt="Screen Shot 2021-11-17 at 9 59 52 PM" src="https://user-images.githubusercontent.com/8311368/142360762-6c4b17e9-c059-45b5-bde2-b538a6eb9433.png">