### PR TITLE
bump reactstrap from 8.10.1 to 9.0.1 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "react-scripts": "4.0.3",
         "react-spinners": "^0.11.0",
         "react-split-pane": "^0.1.92",
-        "reactstrap": "^8.10.1",
+        "reactstrap": "^9.0.1",
         "redux": "^4.1.2"
       },
       "devDependencies": {
@@ -2429,19 +2429,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
     },
-    "node_modules/@hypnosphi/create-react-context": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
-      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
-      "dependencies": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": ">=0.14.0"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -3149,6 +3136,15 @@
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
+      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -7813,11 +7809,12 @@
       }
     },
     "node_modules/dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
       "dependencies": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -10588,11 +10585,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "optional": true
-    },
-    "node_modules/gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "node_modules/gzip-size": {
       "version": "5.1.1",
@@ -16010,16 +16002,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -19725,6 +19707,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -19751,23 +19738,6 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.0 || ^16 || ^17",
         "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17"
-      }
-    },
-    "node_modules/react-popper": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
-      "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "@hypnosphi/create-react-context": "^0.3.1",
-        "deep-equal": "^1.1.1",
-        "popper.js": "^1.14.4",
-        "prop-types": "^15.6.1",
-        "typed-styles": "^0.0.7",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "react": "0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/react-redux": {
@@ -19997,30 +19967,44 @@
       }
     },
     "node_modules/reactstrap": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.10.1.tgz",
-      "integrity": "sha512-StjLADa/12yMNjafrSs+UD7sZAGtKpLO9fZp++2Dj0IzJinqY7eQhXlM3nFf0q40YsIcLvQdFc9pKF8PF4f0Qg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.0.1.tgz",
+      "integrity": "sha512-89VOv7SRlAlpS7RwXhzOQkSWkuhBR8LBsPGfNHifNL3WhtNP9y1sBdTcTYyH1ee2QtI8zRdwD0T5I/blHiwemg==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
+        "@popperjs/core": "^2.6.0",
         "classnames": "^2.2.3",
         "prop-types": "^15.5.8",
-        "react-popper": "^1.3.6",
-        "react-transition-group": "^3.0.0"
+        "react-popper": "^2.2.4",
+        "react-transition-group": "^4.4.2"
       },
       "peerDependencies": {
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/reactstrap/node_modules/react-popper": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17"
       }
     },
     "node_modules/reactstrap/node_modules/react-transition-group": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-3.0.0.tgz",
-      "integrity": "sha512-A9ojB/LWECbFj58SNfjK1X9aaAU+1olLS0DFSikvrr2KfMaiBELemHDa5dKNvcTk2t3gUtDL/PJpFrBKDfMpLg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+      "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
       "dependencies": {
-        "dom-helpers": "^3.4.0",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
+        "prop-types": "^15.6.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0",
@@ -23012,11 +22996,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/typed-styles": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
@@ -26920,15 +26899,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
     },
-    "@hypnosphi/create-react-context": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
-      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      }
-    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -27449,6 +27419,11 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
+    },
+    "@popperjs/core": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
+      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -31128,11 +31103,12 @@
       }
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "dom-serializer": {
@@ -33206,11 +33182,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "optional": true
-    },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -37326,11 +37297,6 @@
         "ts-pnp": "^1.1.6"
       }
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
     "portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -40131,6 +40097,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -40150,20 +40121,6 @@
         "prop-types": "^15.7.2",
         "react-lifecycles-compat": "^3.0.0",
         "warning": "^4.0.3"
-      }
-    },
-    "react-popper": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
-      "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "@hypnosphi/create-react-context": "^0.3.1",
-        "deep-equal": "^1.1.1",
-        "popper.js": "^1.14.4",
-        "prop-types": "^15.6.1",
-        "typed-styles": "^0.0.7",
-        "warning": "^4.0.2"
       }
     },
     "react-redux": {
@@ -40337,26 +40294,36 @@
       }
     },
     "reactstrap": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.10.1.tgz",
-      "integrity": "sha512-StjLADa/12yMNjafrSs+UD7sZAGtKpLO9fZp++2Dj0IzJinqY7eQhXlM3nFf0q40YsIcLvQdFc9pKF8PF4f0Qg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.0.1.tgz",
+      "integrity": "sha512-89VOv7SRlAlpS7RwXhzOQkSWkuhBR8LBsPGfNHifNL3WhtNP9y1sBdTcTYyH1ee2QtI8zRdwD0T5I/blHiwemg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
+        "@popperjs/core": "^2.6.0",
         "classnames": "^2.2.3",
         "prop-types": "^15.5.8",
-        "react-popper": "^1.3.6",
-        "react-transition-group": "^3.0.0"
+        "react-popper": "^2.2.4",
+        "react-transition-group": "^4.4.2"
       },
       "dependencies": {
-        "react-transition-group": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-3.0.0.tgz",
-          "integrity": "sha512-A9ojB/LWECbFj58SNfjK1X9aaAU+1olLS0DFSikvrr2KfMaiBELemHDa5dKNvcTk2t3gUtDL/PJpFrBKDfMpLg==",
+        "react-popper": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+          "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
           "requires": {
-            "dom-helpers": "^3.4.0",
+            "react-fast-compare": "^3.0.1",
+            "warning": "^4.0.2"
+          }
+        },
+        "react-transition-group": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+          "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
             "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
+            "prop-types": "^15.6.2"
           }
         }
       }
@@ -42718,11 +42685,6 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
-    },
-    "typed-styles": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-scripts": "4.0.3",
     "react-spinners": "^0.11.0",
     "react-split-pane": "^0.1.92",
-    "reactstrap": "^8.10.1",
+    "reactstrap": "^9.0.1",
     "redux": "^4.1.2"
   },
   "scripts": {

--- a/src/components/TextEditor/components/ShareSketchModal.js
+++ b/src/components/TextEditor/components/ShareSketchModal.js
@@ -45,13 +45,11 @@ class ShareSketchModal extends React.Component {
       <h2 className="text-center">Share This Sketch</h2>
       <InputGroup>
         <Input value={this.props.shareUrl} disabled />
-        <InputGroupAddon addonType="append">
-          <Button color="primary" onClick={this.initiateCopy}>
-            <FontAwesomeIcon icon={faCopy} />
-            {' '}
-            Copy to Clipboard
-          </Button>
-        </InputGroupAddon>
+        <Button color="primary" onClick={this.initiateCopy}>
+          <FontAwesomeIcon icon={faCopy} />
+          {' '}
+          Copy to Clipboard
+        </Button>
       </InputGroup>
       <hr />
       <p className="text-center">{this.state.copyStatus}</p>

--- a/src/components/TextEditor/components/ShareSketchModal.js
+++ b/src/components/TextEditor/components/ShareSketchModal.js
@@ -4,7 +4,7 @@ import React from 'react';
 import ReactModal from 'react-modal';
 
 import {
-  Button, Input, InputGroup, InputGroupAddon,
+  Button, Input, InputGroup,
 } from 'reactstrap';
 
 import '../../../styles/Modals.scss';
@@ -18,9 +18,12 @@ import '../../../styles/Modals.scss';
  * @param {String} shareUrl the URL to display/copy to clipboard
  */
 class ShareSketchModal extends React.Component {
-  state = {
-    copyStatus: 'Hit "Copy to Clipboard"!',
-  };
+  constructor(props) {
+    super(props);
+    state = {
+      copyStatus: 'Hit "Copy to Clipboard"!',
+    };
+  }
 
   initiateCopy = () => {
     navigator.clipboard.writeText(this.props.shareUrl).then(

--- a/src/components/TextEditor/components/ShareSketchModal.js
+++ b/src/components/TextEditor/components/ShareSketchModal.js
@@ -3,9 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import ReactModal from 'react-modal';
 
-import {
-  Button, Input, InputGroup,
-} from 'reactstrap';
+import { Button, Input, InputGroup } from 'reactstrap';
 
 import '../../../styles/Modals.scss';
 
@@ -39,15 +37,11 @@ class ShareSketchModal extends React.Component {
     );
   };
 
-  render() { 
-    const {
-      showModal,
-      toggleModal,
-      shareUrl
-    } = this.props;
+  render() {
+    const { showModal, toggleModal, shareUrl } = this.props;
 
     const { copyStatus } = this.state;
-    
+
     return (
       <ReactModal
         className="modal-md"
@@ -66,10 +60,10 @@ class ShareSketchModal extends React.Component {
           </Button>
         </InputGroup>
         <hr />
-        <p className="text-center">{this.state.copyStatus}</p>
+        <p className="text-center">{copyStatus}</p>
       </ReactModal>
-      );
-  };
+    );
+  }
 }
 
 export default ShareSketchModal;

--- a/src/components/TextEditor/components/ShareSketchModal.js
+++ b/src/components/TextEditor/components/ShareSketchModal.js
@@ -38,25 +38,34 @@ class ShareSketchModal extends React.Component {
     );
   };
 
-  render() { return <ReactModal
-      className="modal-md"
-      overlayClassName="modal-overlay"
-      isOpen={this.props.showModal}
-      onRequestClose={this.props.toggleModal}
-      ariaHideApp={false}
-    >
-      <h2 className="text-center">Share This Sketch</h2>
-      <InputGroup>
-        <Input value={this.props.shareUrl} disabled />
-        <Button color="primary" onClick={this.initiateCopy}>
-          <FontAwesomeIcon icon={faCopy} />
-          {' '}
-          Copy to Clipboard
-        </Button>
-      </InputGroup>
-      <hr />
-      <p className="text-center">{this.state.copyStatus}</p>
-    </ReactModal>
+  render() { 
+    const {
+      showModal,
+      toggleModal,
+      shareUrl
+    } = this.props;
+
+    return (
+      <ReactModal
+        className="modal-md"
+        overlayClassName="modal-overlay"
+        isOpen={showModal}
+        onRequestClose={toggleModal}
+        ariaHideApp={false}
+      >
+        <h2 className="text-center">Share This Sketch</h2>
+        <InputGroup>
+          <Input value={shareUrl} disabled />
+          <Button color="primary" onClick={this.initiateCopy}>
+            <FontAwesomeIcon icon={faCopy} />
+            {' '}
+            Copy to Clipboard
+          </Button>
+        </InputGroup>
+        <hr />
+        <p className="text-center">{this.state.copyStatus}</p>
+      </ReactModal>
+      );
   };
 }
 

--- a/src/components/TextEditor/components/ShareSketchModal.js
+++ b/src/components/TextEditor/components/ShareSketchModal.js
@@ -26,7 +26,8 @@ class ShareSketchModal extends React.Component {
   }
 
   initiateCopy = () => {
-    navigator.clipboard.writeText(this.props.shareUrl).then(
+    const { shareUrl } = this.props;
+    navigator.clipboard.writeText(shareUrl).then(
       () => {
         // success
         this.setState({ copyStatus: 'Successfully copied!' });

--- a/src/components/TextEditor/components/ShareSketchModal.js
+++ b/src/components/TextEditor/components/ShareSketchModal.js
@@ -46,6 +46,8 @@ class ShareSketchModal extends React.Component {
       shareUrl
     } = this.props;
 
+    const { copyStatus } = this.state;
+    
     return (
       <ReactModal
         className="modal-md"

--- a/src/components/TextEditor/components/ShareSketchModal.js
+++ b/src/components/TextEditor/components/ShareSketchModal.js
@@ -20,7 +20,7 @@ import '../../../styles/Modals.scss';
 class ShareSketchModal extends React.Component {
   constructor(props) {
     super(props);
-    state = {
+    this.state = {
       copyStatus: 'Hit "Copy to Clipboard"!',
     };
   }

--- a/src/components/common/__snapshots__/DropdownButton.test.js.snap
+++ b/src/components/common/__snapshots__/DropdownButton.test.js.snap
@@ -7,7 +7,6 @@ exports[`DropdownButton handles defaultOpen properly 1`] = `
   <Dropdown
     a11y={true}
     active={false}
-    addonType={false}
     direction="down"
     inNavbar={false}
     isOpen={true}
@@ -47,6 +46,7 @@ exports[`DropdownButton handles defaultOpen properly 1`] = `
     </DropdownToggle>
     <DropdownMenu
       flip={true}
+      modifiers={Array []}
       tag="div"
     >
       <DropdownItem
@@ -157,7 +157,6 @@ exports[`DropdownButton handles defaultOpen properly 2`] = `
   <Dropdown
     a11y={true}
     active={false}
-    addonType={false}
     direction="down"
     inNavbar={false}
     isOpen={false}
@@ -197,6 +196,7 @@ exports[`DropdownButton handles defaultOpen properly 2`] = `
     </DropdownToggle>
     <DropdownMenu
       flip={true}
+      modifiers={Array []}
       tag="div"
     >
       <DropdownItem
@@ -307,7 +307,6 @@ exports[`DropdownButton handles defaultOpen properly 3`] = `
   <Dropdown
     a11y={true}
     active={false}
-    addonType={false}
     direction="down"
     inNavbar={false}
     isOpen={false}
@@ -347,6 +346,7 @@ exports[`DropdownButton handles defaultOpen properly 3`] = `
     </DropdownToggle>
     <DropdownMenu
       flip={true}
+      modifiers={Array []}
       tag="div"
     >
       <DropdownItem
@@ -457,7 +457,6 @@ exports[`DropdownButton renders every dropdown item correctly 1`] = `
   <Dropdown
     a11y={true}
     active={false}
-    addonType={false}
     direction="down"
     inNavbar={false}
     isOpen={true}
@@ -497,6 +496,7 @@ exports[`DropdownButton renders every dropdown item correctly 1`] = `
     </DropdownToggle>
     <DropdownMenu
       flip={true}
+      modifiers={Array []}
       tag="div"
     >
       <DropdownItem


### PR DESCRIPTION
Resolves #682 

bump reactstrap from 8.10.1 to 9.0.1 

also fix breaking changes to ShareSketchModal.js due to removal of InputGroupAddon

p.s. minor side note but apologies about the 7 commits, i'm not sure why the failed pre-commits are registering as commits now, i'll have to look into that