### PR TITLE
Move fetch calls out of userDataReducer.js

### DIFF
--- a/src/actions/userDataActions.js
+++ b/src/actions/userDataActions.js
@@ -64,6 +64,11 @@ export function setCurrentClass(cid) {
   return { type: SET_CURRENT_CLASS, value: cid };
 }
 
+export const SET_ERROR = 'SET_ERROR';
+export function setError(errorMsg) {
+  return { type: SET_ERROR, value: errorMsg };
+}
+
 // /**
 //  * dataUpload - attempts to upload program of data into firestore to persist it.
 //  * @param  {[type]} program - the program to upload

--- a/src/actions/userDataActions.js
+++ b/src/actions/userDataActions.js
@@ -64,11 +64,6 @@ export function setCurrentClass(cid) {
   return { type: SET_CURRENT_CLASS, value: cid };
 }
 
-export const SET_ERROR = 'SET_ERROR';
-export function setError(errorMsg) {
-  return { type: SET_ERROR, value: errorMsg };
-}
-
 // /**
 //  * dataUpload - attempts to upload program of data into firestore to persist it.
 //  * @param  {[type]} program - the program to upload

--- a/src/components/Sketches/components/ConfirmDeleteModal.js
+++ b/src/components/Sketches/components/ConfirmDeleteModal.js
@@ -31,16 +31,16 @@ const ConfirmDeleteModal = (props) => {
   const handleSetMostRecentProgram = (program) => {
     try {
       fetch
-      .updateUserData(uid, { mostRecentProgram: program })
-      .catch((err) => {
-        setUserDataError(err);
-        console.log(err);
-      });
+        .updateUserData(uid, { mostRecentProgram: program })
+        .catch((err) => {
+          setUserDataError(err);
+          console.log(err);
+        });
     } catch (err) {
       console.log(err);
     }
     setMostRecentProgram(program);
-  }
+  };
 
   const onDeleteSubmit = () => {
     const data = {

--- a/src/components/Sketches/components/ConfirmDeleteModal.js
+++ b/src/components/Sketches/components/ConfirmDeleteModal.js
@@ -34,10 +34,10 @@ const ConfirmDeleteModal = (props) => {
         .updateUserData(uid, { mostRecentProgram: program })
         .catch((err) => {
           setUserDataError(err);
-          console.log(err);
+          console.error(err);
         });
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
     setMostRecentProgram(program);
   };

--- a/src/components/Sketches/components/ConfirmDeleteModal.js
+++ b/src/components/Sketches/components/ConfirmDeleteModal.js
@@ -27,19 +27,6 @@ const ConfirmDeleteModal = (props) => {
     }
   };
 
-  const handleSetMostRecentProgram = (program) => {
-    try {
-      fetch
-        .updateUserData(uid, { mostRecentProgram: program })
-        .catch((err) => {
-          console.error(err);
-        });
-    } catch (err) {
-      console.error(err);
-    }
-    setMostRecentProgram(program);
-  };
-
   const onDeleteSubmit = () => {
     const data = {
       uid,
@@ -62,9 +49,9 @@ const ConfirmDeleteModal = (props) => {
           // then we need to re-populate it with something different.
           if (programKeys.size > 0 && sketchKey === mostRecentProgram) {
             if (sketchKey === programKeys.get(0)) {
-              handleSetMostRecentProgram(programKeys.get(1));
+              setMostRecentProgram(programKeys.get(1), uid);
             } else {
-              handleSetMostRecentProgram(programKeys.get(0));
+              setMostRecentProgram(programKeys.get(0), uid);
             }
           }
 

--- a/src/components/Sketches/components/ConfirmDeleteModal.js
+++ b/src/components/Sketches/components/ConfirmDeleteModal.js
@@ -16,6 +16,7 @@ const ConfirmDeleteModal = (props) => {
     mostRecentProgram,
     programKeys,
     setMostRecentProgram,
+    setUserDataError,
   } = props;
 
   const [_spinner, setSpinner] = useState(true);
@@ -26,6 +27,20 @@ const ConfirmDeleteModal = (props) => {
       onClose();
     }
   };
+
+  const handleSetMostRecentProgram = (program) => {
+    try {
+      fetch
+      .updateUserData(uid, { mostRecentProgram: program })
+      .catch((err) => {
+        setUserDataError(err);
+        console.log(err);
+      });
+    } catch (err) {
+      console.log(err);
+    }
+    setMostRecentProgram(program);
+  }
 
   const onDeleteSubmit = () => {
     const data = {
@@ -49,9 +64,9 @@ const ConfirmDeleteModal = (props) => {
           // then we need to re-populate it with something different.
           if (programKeys.size > 0 && sketchKey === mostRecentProgram) {
             if (sketchKey === programKeys.get(0)) {
-              setMostRecentProgram(programKeys.get(1));
+              handleSetMostRecentProgram(programKeys.get(1));
             } else {
-              setMostRecentProgram(programKeys.get(0));
+              handleSetMostRecentProgram(programKeys.get(0));
             }
           }
 

--- a/src/components/Sketches/components/ConfirmDeleteModal.js
+++ b/src/components/Sketches/components/ConfirmDeleteModal.js
@@ -16,7 +16,6 @@ const ConfirmDeleteModal = (props) => {
     mostRecentProgram,
     programKeys,
     setMostRecentProgram,
-    setUserDataError,
   } = props;
 
   const [_spinner, setSpinner] = useState(true);
@@ -33,7 +32,6 @@ const ConfirmDeleteModal = (props) => {
       fetch
         .updateUserData(uid, { mostRecentProgram: program })
         .catch((err) => {
-          setUserDataError(err);
           console.error(err);
         });
     } catch (err) {

--- a/src/components/Sketches/components/CreateSketchModal.js
+++ b/src/components/Sketches/components/CreateSketchModal.js
@@ -21,6 +21,7 @@ const CreateSketchModal = (props) => {
     isOpen,
     addProgram,
     setMostRecentProgram,
+    setUserDataError,
     wid,
   } = props;
   const toggleProps = { className: '', color: 'primary', size: 'lg' };
@@ -136,6 +137,16 @@ const CreateSketchModal = (props) => {
         .then((json) => {
           const { uid: uidresponse, ...programData } = json;
           addProgram(uidresponse, programData || {});
+          try {
+            fetch
+            .updateUserData(uid, { mostRecentProgram: uidresponse })
+            .catch((err) => {
+              setUserDataError(err);
+              console.log(err);
+            });
+          } catch (err) {
+            console.log(err);
+          }
           setMostRecentProgram(uidresponse);
           setRedirect(true);
           closeModal();

--- a/src/components/Sketches/components/CreateSketchModal.js
+++ b/src/components/Sketches/components/CreateSketchModal.js
@@ -136,16 +136,7 @@ const CreateSketchModal = (props) => {
         .then((json) => {
           const { uid: uidresponse, ...programData } = json;
           addProgram(uidresponse, programData || {});
-          try {
-            fetch
-              .updateUserData(uid, { mostRecentProgram: uidresponse })
-              .catch((err) => {
-                console.error(err);
-              });
-          } catch (err) {
-            console.error(err);
-          }
-          setMostRecentProgram(uidresponse);
+          setMostRecentProgram(uidresponse, uid);
           setRedirect(true);
           closeModal();
         })

--- a/src/components/Sketches/components/CreateSketchModal.js
+++ b/src/components/Sketches/components/CreateSketchModal.js
@@ -139,11 +139,11 @@ const CreateSketchModal = (props) => {
           addProgram(uidresponse, programData || {});
           try {
             fetch
-            .updateUserData(uid, { mostRecentProgram: uidresponse })
-            .catch((err) => {
-              setUserDataError(err);
-              console.log(err);
-            });
+              .updateUserData(uid, { mostRecentProgram: uidresponse })
+              .catch((err) => {
+                setUserDataError(err);
+                console.log(err);
+              });
           } catch (err) {
             console.log(err);
           }

--- a/src/components/Sketches/components/CreateSketchModal.js
+++ b/src/components/Sketches/components/CreateSketchModal.js
@@ -142,10 +142,10 @@ const CreateSketchModal = (props) => {
               .updateUserData(uid, { mostRecentProgram: uidresponse })
               .catch((err) => {
                 setUserDataError(err);
-                console.log(err);
+                console.error(err);
               });
           } catch (err) {
-            console.log(err);
+            console.error(err);
           }
           setMostRecentProgram(uidresponse);
           setRedirect(true);

--- a/src/components/Sketches/components/CreateSketchModal.js
+++ b/src/components/Sketches/components/CreateSketchModal.js
@@ -21,7 +21,6 @@ const CreateSketchModal = (props) => {
     isOpen,
     addProgram,
     setMostRecentProgram,
-    setUserDataError,
     wid,
   } = props;
   const toggleProps = { className: '', color: 'primary', size: 'lg' };
@@ -141,7 +140,6 @@ const CreateSketchModal = (props) => {
             fetch
               .updateUserData(uid, { mostRecentProgram: uidresponse })
               .catch((err) => {
-                setUserDataError(err);
                 console.error(err);
               });
           } catch (err) {

--- a/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
+++ b/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { deleteProgram } from '../../../actions/programsActions';
-import { setMostRecentProgram, setError } from '../../../actions/userDataActions.js';
+import { setMostRecentProgram } from '../../../actions/userDataActions.js';
 import ConfirmDeleteModal from '../components/ConfirmDeleteModal.js';
 
 const mapStateToProps = (state) => {
@@ -16,7 +16,6 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => ({
   deleteProgram: (program, data) => dispatch(deleteProgram(program, data)),
   setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
-  setUserDataError: (errorMsg) => dispatch(setError(errorMsg)),
 });
 
 const ConfirmDeleteModalContainer = connect(

--- a/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
+++ b/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { deleteProgram } from '../../../actions/programsActions';
-import { setMostRecentProgram } from '../../../actions/userDataActions.js';
+import { setMostRecentProgram, setError } from '../../../actions/userDataActions.js';
 import ConfirmDeleteModal from '../components/ConfirmDeleteModal.js';
 
 const mapStateToProps = (state) => {
@@ -16,6 +16,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => ({
   deleteProgram: (program, data) => dispatch(deleteProgram(program, data)),
   setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
+  setUserDataError: (errorMsg) => dispatch(setError(errorMsg)),
 });
 
 const ConfirmDeleteModalContainer = connect(

--- a/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
+++ b/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
@@ -15,7 +15,18 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => ({
   deleteProgram: (program, data) => dispatch(deleteProgram(program, data)),
-  setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
+  setMostRecentProgram: (value, uid) => {
+    try {
+      fetch
+        .updateUserData(uid, { mostRecentProgram: value })
+        .catch((err) => {
+          console.error(err);
+        });
+    } catch (err) {
+      console.error(err);
+    }
+    dispatch(setMostRecentProgram(value));
+  },
 });
 
 const ConfirmDeleteModalContainer = connect(

--- a/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
+++ b/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { deleteProgram } from '../../../actions/programsActions';
 import { setMostRecentProgram } from '../../../actions/userDataActions';
+import * as fetch from '../../../lib/fetch';
 import ConfirmDeleteModal from '../components/ConfirmDeleteModal';
 
 const mapStateToProps = (state) => {
@@ -17,11 +18,9 @@ const mapDispatchToProps = (dispatch) => ({
   deleteProgram: (program, data) => dispatch(deleteProgram(program, data)),
   setMostRecentProgram: (value, uid) => {
     try {
-      fetch
-        .updateUserData(uid, { mostRecentProgram: value })
-        .catch((err) => {
-          console.error(err);
-        });
+      fetch.updateUserData(uid, { mostRecentProgram: value }).catch((err) => {
+        console.error(err);
+      });
     } catch (err) {
       console.error(err);
     }

--- a/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
+++ b/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { deleteProgram } from '../../../actions/programsActions';
-import { setMostRecentProgram } from '../../../actions/userDataActions.js';
-import ConfirmDeleteModal from '../components/ConfirmDeleteModal.js';
+import { setMostRecentProgram } from '../../../actions/userDataActions';
+import ConfirmDeleteModal from '../components/ConfirmDeleteModal';
 
 const mapStateToProps = (state) => {
   const { mostRecentProgram, uid } = state.userData;

--- a/src/components/Sketches/containers/CreateSketchModalContainer.js
+++ b/src/components/Sketches/containers/CreateSketchModalContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { addProgram } from '../../../actions/programsActions';
-import { setMostRecentProgram, setError } from '../../../actions/userDataActions.js';
+import { setMostRecentProgram } from '../../../actions/userDataActions.js';
 import CreateSketchModal from '../components/CreateSketchModal.js';
 
 const mapStateToProps = (state) => ({
@@ -10,7 +10,6 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   addProgram: (program, data) => dispatch(addProgram(program, data)),
   setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
-  setUserDataError: (errorMsg) => dispatch(setError(errorMsg)),
 });
 
 const CreateSketchModalContainer = connect(

--- a/src/components/Sketches/containers/CreateSketchModalContainer.js
+++ b/src/components/Sketches/containers/CreateSketchModalContainer.js
@@ -9,7 +9,18 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
   addProgram: (program, data) => dispatch(addProgram(program, data)),
-  setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
+  setMostRecentProgram: (value, uid) => {
+    try {
+      fetch
+        .updateUserData(uid, { mostRecentProgram: value })
+        .catch((err) => {
+          console.error(err);
+        });
+    } catch (err) {
+      console.error(err);
+    }
+    dispatch(setMostRecentProgram(value));
+  },
 });
 
 const CreateSketchModalContainer = connect(

--- a/src/components/Sketches/containers/CreateSketchModalContainer.js
+++ b/src/components/Sketches/containers/CreateSketchModalContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { addProgram } from '../../../actions/programsActions';
-import { setMostRecentProgram } from '../../../actions/userDataActions.js';
-import CreateSketchModal from '../components/CreateSketchModal.js';
+import { setMostRecentProgram } from '../../../actions/userDataActions';
+import CreateSketchModal from '../components/CreateSketchModal';
 
 const mapStateToProps = (state) => ({
   uid: state.userData.uid,

--- a/src/components/Sketches/containers/CreateSketchModalContainer.js
+++ b/src/components/Sketches/containers/CreateSketchModalContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { addProgram } from '../../../actions/programsActions';
-import { setMostRecentProgram } from '../../../actions/userDataActions.js';
+import { setMostRecentProgram, setError } from '../../../actions/userDataActions.js';
 import CreateSketchModal from '../components/CreateSketchModal.js';
 
 const mapStateToProps = (state) => ({
@@ -10,6 +10,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   addProgram: (program, data) => dispatch(addProgram(program, data)),
   setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
+  setUserDataError: (errorMsg) => dispatch(setError(errorMsg)),
 });
 
 const CreateSketchModalContainer = connect(

--- a/src/components/Sketches/containers/CreateSketchModalContainer.js
+++ b/src/components/Sketches/containers/CreateSketchModalContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { addProgram } from '../../../actions/programsActions';
 import { setMostRecentProgram } from '../../../actions/userDataActions';
+import * as fetch from '../../../lib/fetch';
 import CreateSketchModal from '../components/CreateSketchModal';
 
 const mapStateToProps = (state) => ({
@@ -11,11 +12,9 @@ const mapDispatchToProps = (dispatch) => ({
   addProgram: (program, data) => dispatch(addProgram(program, data)),
   setMostRecentProgram: (value, uid) => {
     try {
-      fetch
-        .updateUserData(uid, { mostRecentProgram: value })
-        .catch((err) => {
-          console.error(err);
-        });
+      fetch.updateUserData(uid, { mostRecentProgram: value }).catch((err) => {
+        console.error(err);
+      });
     } catch (err) {
       console.error(err);
     }
@@ -23,9 +22,6 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-const CreateSketchModalContainer = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(CreateSketchModal);
+const CreateSketchModalContainer = connect(mapStateToProps, mapDispatchToProps)(CreateSketchModal);
 
 export default CreateSketchModalContainer;

--- a/src/components/Sketches/containers/SketchesContainer.js
+++ b/src/components/Sketches/containers/SketchesContainer.js
@@ -1,7 +1,7 @@
 import Immutable from 'immutable';
 import { connect } from 'react-redux';
 import { togglePanel } from '../../../actions/uiActions.js';
-import { setMostRecentProgram } from '../../../actions/userDataActions.js';
+import { setMostRecentProgram, setError } from '../../../actions/userDataActions.js';
 import { OPEN_PANEL_LEFT, CLOSED_PANEL_LEFT, PANEL_SIZE } from '../../../constants';
 import { getLanguageData } from '../../../util/languages/languages.js';
 import Sketches from '../index.js';
@@ -25,11 +25,13 @@ const mapStateToProps = (state) => {
     left,
     screenHeight: state.ui.screenHeight,
     panelOpen: state.ui.panelOpen,
+    uid: state.userData.uid,
   };
 };
 
 const mapDispatchToProps = (dispatch) => ({
   setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
+  setError: (value) => dispatch(setError(value)),
   togglePanel: () => dispatch(togglePanel()),
 });
 

--- a/src/components/Sketches/containers/SketchesContainer.js
+++ b/src/components/Sketches/containers/SketchesContainer.js
@@ -30,7 +30,18 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-  setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
+  setMostRecentProgram: (value, uid) => {
+    try {
+      fetch
+        .updateUserData(uid, { mostRecentProgram: value })
+        .catch((err) => {
+          console.error(err);
+        });
+    } catch (err) {
+      console.error(err);
+    }
+    dispatch(setMostRecentProgram(value));
+  },
   togglePanel: () => dispatch(togglePanel()),
 });
 

--- a/src/components/Sketches/containers/SketchesContainer.js
+++ b/src/components/Sketches/containers/SketchesContainer.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { togglePanel } from '../../../actions/uiActions';
 import { setMostRecentProgram } from '../../../actions/userDataActions';
 import { OPEN_PANEL_LEFT, CLOSED_PANEL_LEFT, PANEL_SIZE } from '../../../constants';
+import * as fetch from '../../../lib/fetch';
 import { getLanguageData } from '../../../util/languages/languages';
 import Sketches from '../index';
 
@@ -32,11 +33,9 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => ({
   setMostRecentProgram: (value, uid) => {
     try {
-      fetch
-        .updateUserData(uid, { mostRecentProgram: value })
-        .catch((err) => {
-          console.error(err);
-        });
+      fetch.updateUserData(uid, { mostRecentProgram: value }).catch((err) => {
+        console.error(err);
+      });
     } catch (err) {
       console.error(err);
     }

--- a/src/components/Sketches/containers/SketchesContainer.js
+++ b/src/components/Sketches/containers/SketchesContainer.js
@@ -1,7 +1,7 @@
 import Immutable from 'immutable';
 import { connect } from 'react-redux';
 import { togglePanel } from '../../../actions/uiActions.js';
-import { setMostRecentProgram, setError } from '../../../actions/userDataActions.js';
+import { setMostRecentProgram } from '../../../actions/userDataActions.js';
 import { OPEN_PANEL_LEFT, CLOSED_PANEL_LEFT, PANEL_SIZE } from '../../../constants';
 import { getLanguageData } from '../../../util/languages/languages.js';
 import Sketches from '../index.js';
@@ -31,7 +31,6 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => ({
   setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
-  setError: (value) => dispatch(setError(value)),
   togglePanel: () => dispatch(togglePanel()),
 });
 

--- a/src/components/Sketches/containers/SketchesContainer.js
+++ b/src/components/Sketches/containers/SketchesContainer.js
@@ -1,10 +1,10 @@
 import Immutable from 'immutable';
 import { connect } from 'react-redux';
-import { togglePanel } from '../../../actions/uiActions.js';
-import { setMostRecentProgram } from '../../../actions/userDataActions.js';
+import { togglePanel } from '../../../actions/uiActions';
+import { setMostRecentProgram } from '../../../actions/userDataActions';
 import { OPEN_PANEL_LEFT, CLOSED_PANEL_LEFT, PANEL_SIZE } from '../../../constants';
-import { getLanguageData } from '../../../util/languages/languages.js';
-import Sketches from '../index.js';
+import { getLanguageData } from '../../../util/languages/languages';
+import Sketches from '../index';
 
 const mapStateToProps = (state) => {
   const { mostRecentProgram } = state.userData;

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -51,7 +51,10 @@ class Sketches extends React.Component {
   };
 
   setProgram = (name) => {
-    this.props.setMostRecentProgram(name, this.props.uid);
+    const { uid } = this.props;
+
+    // eslint-disable-next-line react/destructuring-assignment
+    this.props.setMostRecentProgram(name, uid);
   };
 
   renderHeader = () => (
@@ -79,7 +82,9 @@ class Sketches extends React.Component {
   };
 
   renderSketches = () => {
-    const newList = this.props.programs.concat([]);
+    const { programs } = this.props;
+
+    const newList = programs.concat([]);
     if (newList.size === 0) {
       return (
         <div>
@@ -132,7 +137,9 @@ class Sketches extends React.Component {
         />,
       );
     });
-    const numSketchesPerRow = Math.floor((this.props.calculatedWidth - ROW_PADDING) / SKETCH_WIDTH);
+
+    const { calculatedWidth } = this.props;
+    const numSketchesPerRow = Math.floor((calculatedWidth - ROW_PADDING) / SKETCH_WIDTH);
     const rows = [];
     const originalLength = sketches.length;
     for (let i = 0; i < originalLength / numSketchesPerRow; i++) {
@@ -146,32 +153,48 @@ class Sketches extends React.Component {
     return <div className="sketches-grid">{rows}</div>;
   };
 
-  renderConfirmDeleteModal = () => (
-    <ConfirmDeleteModalContainer
-      isOpen={this.state.confirmDeleteModalOpen}
-      onClose={() => this.setState({ confirmDeleteModalOpen: false })}
-      sketchName={this.state.selectedSketch}
-      sketchKey={this.state.selectedKey}
-    />
-  );
+  renderConfirmDeleteModal = () => {
+    const { confirmDeleteModalOpen, selectedSketch, selectedKey } = this.state;
+    return (
+      <ConfirmDeleteModalContainer
+        isOpen={confirmDeleteModalOpen}
+        onClose={() => this.setState({ confirmDeleteModalOpen: false })}
+        sketchName={selectedSketch}
+        sketchKey={selectedKey}
+      />
+    );
+  };
 
-  renderCreateSketchModal = () => (
-    <CreateSketchModalContainer
-      isOpen={this.state.createSketchModalOpen}
-      onClose={() => this.setState({ createSketchModalOpen: false })}
-    />
-  );
+  renderCreateSketchModal = () => {
+    const { createSketchModalOpen } = this.state;
+    return (
+      <CreateSketchModalContainer
+        isOpen={createSketchModalOpen}
+        onClose={() => this.setState({ createSketchModalOpen: false })}
+      />
+    );
+  };
 
-  renderEditSketchModal = () => (
-    <EditSketchModalContainer
-      isOpen={this.state.editSketchModalOpen}
-      onClose={() => this.setState({ editSketchModalOpen: false })}
-      sketchName={this.state.selectedSketch}
-      sketchImg={this.state.selectedImg}
-      sketchLang={this.state.selectedLang}
-      sketchKey={this.state.selectedKey}
-    />
-  );
+  renderEditSketchModal = () => {
+    const {
+      editSketchModalOpen,
+      selectedSketch,
+      selectedImg,
+      selectedLang,
+      selectedKey,
+    } = this.state;
+
+    return (
+      <EditSketchModalContainer
+        isOpen={editSketchModalOpen}
+        onClose={() => this.setState({ editSketchModalOpen: false })}
+        sketchName={selectedSketch}
+        sketchImg={selectedImg}
+        sketchLang={selectedLang}
+        sketchKey={selectedKey}
+      />
+    );
+  };
 
   renderContent = () => (
     <>
@@ -184,9 +207,10 @@ class Sketches extends React.Component {
   );
 
   render() {
+    const { calculatedWidth, screenHeight } = this.props;
     const containerStyle = {
-      width: this.props.calculatedWidth,
-      height: this.props.screenHeight,
+      width: calculatedWidth,
+      height: screenHeight,
     };
 
     return (

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -6,14 +6,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import { Button } from 'reactstrap';
 import { ThumbnailArray } from '../../constants';
+import * as fetch from '../../lib/fetch';
 import CodeDownloader from '../../util/languages/CodeDownloader';
 import OpenPanelButtonContainer from '../common/containers/OpenPanelButtonContainer';
 import SketchBox from '../common/SketchBox';
 import ConfirmDeleteModalContainer from './containers/ConfirmDeleteModalContainer';
 import CreateSketchModalContainer from './containers/CreateSketchModalContainer';
 import EditSketchModalContainer from './containers/EditSketchModalContainer';
-
-import * as fetch from '../../lib/fetch';
 
 const ROW_PADDING = 100;
 const SKETCH_WIDTH = 220;
@@ -55,11 +54,11 @@ class Sketches extends React.Component {
   setProgram = (name) => {
     try {
       fetch
-      .updateUserData(this.props.uid, { mostRecentProgram: name })
-      .catch((err) => {
-        this.props.setError(err);
-        console.log(err);
-      });
+        .updateUserData(this.props.uid, { mostRecentProgram: name })
+        .catch((err) => {
+          this.props.setError(err);
+          console.log(err);
+        });
     } catch (err) {
       console.log(err);
     }

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -30,8 +30,6 @@ class Sketches extends React.Component {
     };
   }
 
-  getRandomSketchThumbnail = () => ThumbnailArray[Math.floor(Math.random() * ThumbnailArray.length)];
-
   setCreateSketchModalOpen = (val) => {
     this.setState({ createSketchModalOpen: val });
   };
@@ -177,11 +175,7 @@ class Sketches extends React.Component {
 
   renderEditSketchModal = () => {
     const {
-      editSketchModalOpen,
-      selectedSketch,
-      selectedImg,
-      selectedLang,
-      selectedKey,
+      editSketchModalOpen, selectedSketch, selectedImg, selectedLang, selectedKey,
     } = this.state;
 
     return (

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -6,7 +6,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import { Button } from 'reactstrap';
 import { ThumbnailArray } from '../../constants';
-import * as fetch from '../../lib/fetch';
 import CodeDownloader from '../../util/languages/CodeDownloader';
 import OpenPanelButtonContainer from '../common/containers/OpenPanelButtonContainer';
 import SketchBox from '../common/SketchBox';
@@ -52,16 +51,7 @@ class Sketches extends React.Component {
   };
 
   setProgram = (name) => {
-    try {
-      fetch
-        .updateUserData(this.props.uid, { mostRecentProgram: name })
-        .catch((err) => {
-          console.error(err);
-        });
-    } catch (err) {
-      console.error(err);
-    }
-    this.props.setMostRecentProgram(name);
+    this.props.setMostRecentProgram(name, this.props.uid);
   };
 
   renderHeader = () => (

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -51,6 +51,16 @@ class Sketches extends React.Component {
   };
 
   setProgram = (name) => {
+    try {
+      fetch
+      .updateUserData(this.props.uid, { mostRecentProgram: name })
+      .catch((err) => {
+        this.props.setError(err);
+        console.log(err);
+      });
+    } catch (err) {
+      console.log(err);
+    }
     this.props.setMostRecentProgram(name);
   };
 

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -49,9 +49,9 @@ class Sketches extends React.Component {
   };
 
   setProgram = (name) => {
-    const { uid } = this.props;
+    const { uid, setMostRecentProgram } = this.props;
 
-    this.props.setMostRecentProgram(name, uid);
+    setMostRecentProgram(name, uid);
   };
 
   renderHeader = () => (

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -51,7 +51,6 @@ class Sketches extends React.Component {
   setProgram = (name) => {
     const { uid } = this.props;
 
-    // eslint-disable-next-line react/destructuring-assignment
     this.props.setMostRecentProgram(name, uid);
   };
 

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -56,7 +56,6 @@ class Sketches extends React.Component {
       fetch
         .updateUserData(this.props.uid, { mostRecentProgram: name })
         .catch((err) => {
-          this.props.setError(err);
           console.error(err);
         });
     } catch (err) {

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -13,6 +13,8 @@ import ConfirmDeleteModalContainer from './containers/ConfirmDeleteModalContaine
 import CreateSketchModalContainer from './containers/CreateSketchModalContainer';
 import EditSketchModalContainer from './containers/EditSketchModalContainer';
 
+import * as fetch from '../../lib/fetch';
+
 const ROW_PADDING = 100;
 const SKETCH_WIDTH = 220;
 

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -57,10 +57,10 @@ class Sketches extends React.Component {
         .updateUserData(this.props.uid, { mostRecentProgram: name })
         .catch((err) => {
           this.props.setError(err);
-          console.log(err);
+          console.error(err);
         });
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
     this.props.setMostRecentProgram(name);
   };

--- a/src/components/TextEditor/containers/DropdownButtonContainer.js
+++ b/src/components/TextEditor/containers/DropdownButtonContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { setMostRecentProgram, setError } from '../../../actions/userDataActions.js';
+import { setMostRecentProgram } from '../../../actions/userDataActions.js';
 import { getLanguageData } from '../../../util/languages/languages.js';
 import DropdownButton from '../../common/DropdownButton.js';
 
@@ -43,7 +43,6 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => ({
   setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
-  setUserDataError: (errorMsg) => dispatch(setError(errorMsg)),
 });
 
 const DropdownButtonContainer = connect(mapStateToProps, mapDispatchToProps)(DropdownButton);

--- a/src/components/TextEditor/containers/DropdownButtonContainer.js
+++ b/src/components/TextEditor/containers/DropdownButtonContainer.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { setMostRecentProgram } from '../../../actions/userDataActions';
+import * as fetch from '../../../lib/fetch';
 import { getLanguageData } from '../../../util/languages/languages';
 import DropdownButton from '../../common/DropdownButton';
 

--- a/src/components/TextEditor/containers/DropdownButtonContainer.js
+++ b/src/components/TextEditor/containers/DropdownButtonContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { setMostRecentProgram } from '../../../actions/userDataActions.js';
+import { setMostRecentProgram, setError } from '../../../actions/userDataActions.js';
 import { getLanguageData } from '../../../util/languages/languages.js';
 import DropdownButton from '../../common/DropdownButton.js';
 
@@ -37,17 +37,13 @@ const mapStateToProps = (state) => {
     DropdownItems: programStateValues,
     icon,
     toggleProps,
+    uid: state.userData.uid,
   };
 };
 
 const mapDispatchToProps = (dispatch) => ({
-  onSelect: ({ display, value, dirty }) => {
-    if (dirty) {
-      result = window.confirm('Are you sure you want to change programs? You have unsaved changes');
-    } else {
-      dispatch(setMostRecentProgram(value));
-    }
-  },
+  setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
+  setUserDataError: (errorMsg) => dispatch(setError(errorMsg)),
 });
 
 const DropdownButtonContainer = connect(mapStateToProps, mapDispatchToProps)(DropdownButton);

--- a/src/components/TextEditor/containers/DropdownButtonContainer.js
+++ b/src/components/TextEditor/containers/DropdownButtonContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
-import { setMostRecentProgram } from '../../../actions/userDataActions.js';
-import { getLanguageData } from '../../../util/languages/languages.js';
-import DropdownButton from '../../common/DropdownButton.js';
+import { setMostRecentProgram } from '../../../actions/userDataActions';
+import { getLanguageData } from '../../../util/languages/languages';
+import DropdownButton from '../../common/DropdownButton';
 
 const mapStateToProps = (state) => {
   const { mostRecentProgram } = state.userData;
@@ -42,7 +42,12 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-  onSelect: ({ display, value, dirty, uid }) => {
+  onSelect: ({
+    display,
+    value,
+    dirty,
+    uid,
+  }) => {
     if (dirty) {
       result = window.confirm('Are you sure you want to change programs? You have unsaved changes');
     } else {

--- a/src/components/TextEditor/containers/DropdownButtonContainer.js
+++ b/src/components/TextEditor/containers/DropdownButtonContainer.js
@@ -43,25 +43,20 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => ({
   onSelect: ({
-    _display,
-    value,
-    dirty,
-    uid,
+    _display, value, _dirty, uid,
   }) => {
-    if (dirty) {
-      result = window.confirm('Are you sure you want to change programs? You have unsaved changes');
-    } else {
-      try {
-        fetch
-          .updateUserData(uid, { mostRecentProgram: value })
-          .catch((err) => {
-            console.error(err);
-          });
-      } catch (err) {
+    // TODO: Fix this dirty check
+    // if (dirty) {
+    //   result = window.confirm('Are you sure you want to change programs? You have unsaved changes');
+    // }
+    try {
+      fetch.updateUserData(uid, { mostRecentProgram: value }).catch((err) => {
         console.error(err);
-      }
-      dispatch(setMostRecentProgram(value));
+      });
+    } catch (err) {
+      console.error(err);
     }
+    dispatch(setMostRecentProgram(value));
   },
 });
 

--- a/src/components/TextEditor/containers/DropdownButtonContainer.js
+++ b/src/components/TextEditor/containers/DropdownButtonContainer.js
@@ -43,7 +43,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => ({
   onSelect: ({
-    display,
+    _display,
     value,
     dirty,
     uid,

--- a/src/components/TextEditor/containers/DropdownButtonContainer.js
+++ b/src/components/TextEditor/containers/DropdownButtonContainer.js
@@ -42,7 +42,22 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-  setMostRecentProgram: (value) => dispatch(setMostRecentProgram(value)),
+  onSelect: ({ display, value, dirty, uid }) => {
+    if (dirty) {
+      result = window.confirm('Are you sure you want to change programs? You have unsaved changes');
+    } else {
+      try {
+        fetch
+          .updateUserData(uid, { mostRecentProgram: value })
+          .catch((err) => {
+            console.error(err);
+          });
+      } catch (err) {
+        console.error(err);
+      }
+      dispatch(setMostRecentProgram(value));
+    }
+  },
 });
 
 const DropdownButtonContainer = connect(mapStateToProps, mapDispatchToProps)(DropdownButton);

--- a/src/components/common/DropdownButton.js
+++ b/src/components/common/DropdownButton.js
@@ -38,7 +38,12 @@ const DropdownButton = function (props) {
   };
 
   const renderDropdownItems = () => DropdownItems.map(({ display, value, icon }) => (
-    <DropdownItem key={value} onClick={() => onSelect({ display, value, dirty, uid })}>
+    <DropdownItem key={value} onClick={() => onSelect({
+      display,
+      value,
+      dirty,
+      uid,
+    })}>
       <FontAwesomeIcon style={{ marginRight: '10px' }} icon={icon} fixedWidth />
       {display}
     </DropdownItem>

--- a/src/components/common/DropdownButton.js
+++ b/src/components/common/DropdownButton.js
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 import {
   Dropdown, DropdownToggle, DropdownMenu, DropdownItem,
 } from 'reactstrap';
-import * as fetch from '../../lib/fetch';
 
 /** --------Props---------------
  * dropDownItems: array of data for each dropdown item
@@ -25,7 +24,7 @@ const DropdownButton = function (props) {
     displayValue,
     displayClass,
     toggleProps,
-    setMostRecentProgram,
+    onSelect,
     dirty,
   } = props;
 
@@ -38,25 +37,8 @@ const DropdownButton = function (props) {
     setdropdownOpen(!dropdownOpen);
   };
 
-  const onSelect = ({ display, value, dirty }) => {
-    if (dirty) {
-      result = window.confirm('Are you sure you want to change programs? You have unsaved changes');
-    } else {
-      try {
-        fetch
-          .updateUserData(uid, { mostRecentProgram: value })
-          .catch((err) => {
-            console.error(err);
-          });
-      } catch (err) {
-        console.error(err);
-      }
-      setMostRecentProgram(value);
-    }
-  };
-
   const renderDropdownItems = () => DropdownItems.map(({ display, value, icon }) => (
-    <DropdownItem key={value} onClick={() => onSelect({ display, value, dirty })}>
+    <DropdownItem key={value} onClick={() => onSelect({ display, value, dirty, uid })}>
       <FontAwesomeIcon style={{ marginRight: '10px' }} icon={icon} fixedWidth />
       {display}
     </DropdownItem>

--- a/src/components/common/DropdownButton.js
+++ b/src/components/common/DropdownButton.js
@@ -15,7 +15,7 @@ import {
  * defaultOpen: boolean determining if the dropdown should start off open or closed
  */
 
-const DropdownButton = function (props) {
+function DropdownButton(props) {
   const {
     uid,
     icon,
@@ -66,5 +66,6 @@ const DropdownButton = function (props) {
       </Dropdown>
     </div>
   );
-};
+}
+
 export default DropdownButton;

--- a/src/components/common/DropdownButton.js
+++ b/src/components/common/DropdownButton.js
@@ -37,7 +37,7 @@ const DropdownButton = function (props) {
     setdropdownOpen(!dropdownOpen);
   };
 
-  const renderDropdownItems = () => DropdownItems.map(({ display, value, icon }) => (
+  const renderDropdownItems = () => DropdownItems.map(({ display, value, icon: itemIcon }) => (
     <DropdownItem
       key={value}
       onClick={() => onSelect({
@@ -45,8 +45,9 @@ const DropdownButton = function (props) {
         value,
         dirty,
         uid,
-      })}>
-      <FontAwesomeIcon style={{ marginRight: '10px' }} icon={icon} fixedWidth />
+      })}
+    >
+      <FontAwesomeIcon style={{ marginRight: '10px' }} icon={itemIcon} fixedWidth />
       {display}
     </DropdownItem>
   ));
@@ -54,6 +55,7 @@ const DropdownButton = function (props) {
   return (
     <div className={dropDownParentClass}>
       <Dropdown isOpen={dropdownOpen} toggle={() => toggleHandler(dropdownOpen)}>
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
         <DropdownToggle caret {...toggleProps}>
           <div className={dropDownItemClass}>
             <FontAwesomeIcon icon={icon} fixedWidth />

--- a/src/components/common/DropdownButton.js
+++ b/src/components/common/DropdownButton.js
@@ -38,12 +38,14 @@ const DropdownButton = function (props) {
   };
 
   const renderDropdownItems = () => DropdownItems.map(({ display, value, icon }) => (
-    <DropdownItem key={value} onClick={() => onSelect({
-      display,
-      value,
-      dirty,
-      uid,
-    })}>
+    <DropdownItem
+      key={value}
+      onClick={() => onSelect({
+        display,
+        value,
+        dirty,
+        uid,
+      })}>
       <FontAwesomeIcon style={{ marginRight: '10px' }} icon={icon} fixedWidth />
       {display}
     </DropdownItem>

--- a/src/components/common/DropdownButton.js
+++ b/src/components/common/DropdownButton.js
@@ -48,10 +48,10 @@ const DropdownButton = function (props) {
           .updateUserData(uid, { mostRecentProgram: value })
           .catch((err) => {
             setUserDataError(err);
-            console.log(err);
+            console.error(err);
           });
       } catch (err) {
-        console.log(err);
+        console.error(err);
       }
       setMostRecentProgram(value);
     }

--- a/src/components/common/DropdownButton.js
+++ b/src/components/common/DropdownButton.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import {
   Dropdown, DropdownToggle, DropdownMenu, DropdownItem,
 } from 'reactstrap';
+import * as fetch from '../../lib/fetch';
 
 /** --------Props---------------
  * dropDownItems: array of data for each dropdown item

--- a/src/components/common/DropdownButton.js
+++ b/src/components/common/DropdownButton.js
@@ -17,13 +17,15 @@ import {
 
 const DropdownButton = function (props) {
   const {
+    uid,
     icon,
     DropdownItems,
     defaultOpen,
     displayValue,
     displayClass,
     toggleProps,
-    onSelect,
+    setMostRecentProgram,
+    setUserDataError,
     dirty,
   } = props;
 
@@ -34,6 +36,24 @@ const DropdownButton = function (props) {
 
   const toggleHandler = () => {
     setdropdownOpen(!dropdownOpen);
+  };
+
+  const onSelect = ({ display, value, dirty }) => {
+    if (dirty) {
+      result = window.confirm('Are you sure you want to change programs? You have unsaved changes');
+    } else {
+      try {
+        fetch
+          .updateUserData(uid, { mostRecentProgram: value })
+          .catch((err) => {
+            setUserDataError(err);
+            console.log(err);
+          });
+      } catch (err) {
+        console.log(err);
+      }
+      setMostRecentProgram(value);
+    }
   };
 
   const renderDropdownItems = () => DropdownItems.map(({ display, value, icon }) => (

--- a/src/components/common/DropdownButton.js
+++ b/src/components/common/DropdownButton.js
@@ -26,7 +26,6 @@ const DropdownButton = function (props) {
     displayClass,
     toggleProps,
     setMostRecentProgram,
-    setUserDataError,
     dirty,
   } = props;
 
@@ -47,7 +46,6 @@ const DropdownButton = function (props) {
         fetch
           .updateUserData(uid, { mostRecentProgram: value })
           .catch((err) => {
-            setUserDataError(err);
             console.error(err);
           });
       } catch (err) {

--- a/src/components/common/DropdownButton.test.js
+++ b/src/components/common/DropdownButton.test.js
@@ -87,6 +87,7 @@ describe('DropdownButton', () => {
       dirty: undefined,
       display: 'Nice',
       value: 'banana',
+      uid: undefined,
     });
 
     const component2 = shallow(
@@ -105,6 +106,7 @@ describe('DropdownButton', () => {
       dirty: undefined,
       display: 'Cool',
       value: 'apple',
+      uid: undefined,
     });
   });
 });

--- a/src/components/common/ProfilePanel.js
+++ b/src/components/common/ProfilePanel.js
@@ -41,7 +41,6 @@ function ProfilePanel(props) {
     setPhotoName,
     displayName,
     setDisplayName,
-    setUserDataError,
     contentType,
     theme,
     onThemeChange,
@@ -94,7 +93,6 @@ function ProfilePanel(props) {
         fetch
           .updateUserData(uid, { displayName: name })
           .catch((err) => {
-            setUserDataError(err);
             console.error(err);
           });
       } catch (err) {
@@ -124,7 +122,6 @@ function ProfilePanel(props) {
         // otherwise, change it back (or dont, depends how we wanna do it)
         })
         .catch((err) => {
-          setUserDataError(err);
           console.error(err);
         });
     } catch (err) {

--- a/src/components/common/ProfilePanel.js
+++ b/src/components/common/ProfilePanel.js
@@ -14,6 +14,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
+import * as fetch from '../../../lib/fetch';
+
 import { Row, Col, Button } from 'reactstrap';
 import {
   PHOTO_NAMES,
@@ -40,6 +42,7 @@ function ProfilePanel(props) {
     setPhotoName,
     displayName,
     setDisplayName,
+    setUserDataError,
     contentType,
     theme,
     onThemeChange,
@@ -88,6 +91,16 @@ function ProfilePanel(props) {
       setEditingName(true);
       setError(message);
     } else {
+      try {
+        fetch
+          .updateUserData(state.uid, { displayName: name })
+          .catch((err) => {
+            setUserDataError(err);
+            console.log(err);
+          });
+      } catch (err) {
+        console.log(err);
+      }
       setDisplayName(name);
       setEditingName(false);
       setNameSubmitted(true);

--- a/src/components/common/ProfilePanel.js
+++ b/src/components/common/ProfilePanel.js
@@ -22,7 +22,6 @@ import {
   PANEL_IMAGE_SELECTOR_SIZE,
 } from '../../constants';
 import { signOut } from '../../firebase';
-import * as fetch from '../../lib/fetch';
 import '../../styles/Panel.scss';
 
 import { isValidDisplayName } from '../../lib/validate';
@@ -89,16 +88,7 @@ function ProfilePanel(props) {
       setEditingName(true);
       setError(message);
     } else {
-      try {
-        fetch
-          .updateUserData(uid, { displayName: name })
-          .catch((err) => {
-            console.error(err);
-          });
-      } catch (err) {
-        console.error(err);
-      }
-      setDisplayName(name);
+      setDisplayName(name, uid);
       setEditingName(false);
       setNameSubmitted(true);
       setError('');
@@ -113,21 +103,7 @@ function ProfilePanel(props) {
    * closes the modal; resets the state
    */
   const onImageSubmit = () => {
-    // SEND IMAGE NAME TO BACKEND, CHANGE IMAGE
-    try {
-      fetch
-        .updateUserData(uid, { photoName: selectedImage })
-        .then(() => {
-        // TODO: if nothing went bad, keep the display name,
-        // otherwise, change it back (or dont, depends how we wanna do it)
-        })
-        .catch((err) => {
-          console.error(err);
-        });
-    } catch (err) {
-      console.error(err);
-    }
-    setPhotoName(selectedImage);
+    setPhotoName(selectedImage, uid);
     handleCloseModal();
     setSelectedImage('');
   };

--- a/src/components/common/ProfilePanel.js
+++ b/src/components/common/ProfilePanel.js
@@ -14,7 +14,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
-import * as fetch from '../../../lib/fetch';
+import * as fetch from '../../lib/fetch';
 
 import { Row, Col, Button } from 'reactstrap';
 import {

--- a/src/components/common/ProfilePanel.js
+++ b/src/components/common/ProfilePanel.js
@@ -95,10 +95,10 @@ function ProfilePanel(props) {
           .updateUserData(uid, { displayName: name })
           .catch((err) => {
             setUserDataError(err);
-            console.log(err);
+            console.error(err);
           });
       } catch (err) {
-        console.log(err);
+        console.error(err);
       }
       setDisplayName(name);
       setEditingName(false);
@@ -125,10 +125,10 @@ function ProfilePanel(props) {
         })
         .catch((err) => {
           setUserDataError(err);
-          console.log(err);
+          console.error(err);
         });
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
     setPhotoName(selectedImage);
     handleCloseModal();

--- a/src/components/common/ProfilePanel.js
+++ b/src/components/common/ProfilePanel.js
@@ -14,8 +14,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
-import * as fetch from '../../lib/fetch';
-
 import { Row, Col, Button } from 'reactstrap';
 import {
   PHOTO_NAMES,
@@ -24,6 +22,7 @@ import {
   PANEL_IMAGE_SELECTOR_SIZE,
 } from '../../constants';
 import { signOut } from '../../firebase';
+import * as fetch from '../../lib/fetch';
 import '../../styles/Panel.scss';
 
 import { isValidDisplayName } from '../../lib/validate';
@@ -119,15 +118,15 @@ function ProfilePanel(props) {
     // SEND IMAGE NAME TO BACKEND, CHANGE IMAGE
     try {
       fetch
-      .updateUserData(uid, { photoName: selectedImage })
-      .then(() => {
+        .updateUserData(uid, { photoName: selectedImage })
+        .then(() => {
         // TODO: if nothing went bad, keep the display name,
         // otherwise, change it back (or dont, depends how we wanna do it)
-      })
-      .catch((err) => {
-        setUserDataError(err);
-        console.log(err);
-      });
+        })
+        .catch((err) => {
+          setUserDataError(err);
+          console.log(err);
+        });
     } catch (err) {
       console.log(err);
     }

--- a/src/components/common/ProfilePanel.js
+++ b/src/components/common/ProfilePanel.js
@@ -93,7 +93,7 @@ function ProfilePanel(props) {
     } else {
       try {
         fetch
-          .updateUserData(state.uid, { displayName: name })
+          .updateUserData(uid, { displayName: name })
           .catch((err) => {
             setUserDataError(err);
             console.log(err);
@@ -117,6 +117,20 @@ function ProfilePanel(props) {
    */
   const onImageSubmit = () => {
     // SEND IMAGE NAME TO BACKEND, CHANGE IMAGE
+    try {
+      fetch
+      .updateUserData(uid, { photoName: selectedImage })
+      .then(() => {
+        // TODO: if nothing went bad, keep the display name,
+        // otherwise, change it back (or dont, depends how we wanna do it)
+      })
+      .catch((err) => {
+        setUserDataError(err);
+        console.log(err);
+      });
+    } catch (err) {
+      console.log(err);
+    }
     setPhotoName(selectedImage);
     handleCloseModal();
     setSelectedImage('');

--- a/src/components/common/containers/ProfilePanelContainer.js
+++ b/src/components/common/containers/ProfilePanelContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { togglePanel } from '../../../actions/uiActions';
-import { setDisplayName, setPhotoName, setError } from '../../../actions/userDataActions';
+import { setDisplayName, setPhotoName } from '../../../actions/userDataActions';
 import { DEFAULT_PHOTO_NAME, CLOSED_PANEL_LEFT, OPEN_PANEL_LEFT } from '../../../constants';
 import ProfilePanel from '../ProfilePanel';
 
@@ -19,7 +19,6 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   collectUserPhoto: () => {},
   setDisplayName: (name) => dispatch(setDisplayName(name)),
   setPhotoName: (name) => dispatch(setPhotoName(name)),
-  setUserDataError: (errorMsg) => dispatch(setError(errorMsg)),
   togglePanel: () => {
     dispatch(togglePanel());
   },

--- a/src/components/common/containers/ProfilePanelContainer.js
+++ b/src/components/common/containers/ProfilePanelContainer.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import { togglePanel } from '../../../actions/uiActions';
 import { setDisplayName, setPhotoName } from '../../../actions/userDataActions';
 import { DEFAULT_PHOTO_NAME, CLOSED_PANEL_LEFT, OPEN_PANEL_LEFT } from '../../../constants';
+import * as fetch from '../../../lib/fetch';
 import ProfilePanel from '../ProfilePanel';
 
 const mapStateToProps = (state, ownProps) => ({
@@ -19,11 +20,9 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   collectUserPhoto: () => {},
   setDisplayName: (name, uid) => {
     try {
-      fetch
-        .updateUserData(uid, { displayName: name })
-        .catch((err) => {
-          console.error(err);
-        });
+      fetch.updateUserData(uid, { displayName: name }).catch((err) => {
+        console.error(err);
+      });
     } catch (err) {
       console.error(err);
     }
@@ -34,8 +33,8 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
       fetch
         .updateUserData(uid, { photoName: name })
         .then(() => {
-        // TODO: if nothing went bad, keep the display name,
-        // otherwise, change it back (or dont, depends how we wanna do it)
+          // TODO: if nothing went bad, keep the display name,
+          // otherwise, change it back (or dont, depends how we wanna do it)
         })
         .catch((err) => {
           console.error(err);

--- a/src/components/common/containers/ProfilePanelContainer.js
+++ b/src/components/common/containers/ProfilePanelContainer.js
@@ -17,8 +17,34 @@ const mapStateToProps = (state, ownProps) => ({
 const mapDispatchToProps = (dispatch, ownProps) => ({
   onThemeChange: ownProps.onThemeChange,
   collectUserPhoto: () => {},
-  setDisplayName: (name) => dispatch(setDisplayName(name)),
-  setPhotoName: (name) => dispatch(setPhotoName(name)),
+  setDisplayName: (name, uid) => {
+    try {
+      fetch
+        .updateUserData(uid, { displayName: name })
+        .catch((err) => {
+          console.error(err);
+        });
+    } catch (err) {
+      console.error(err);
+    }
+    dispatch(setDisplayName(name));
+  },
+  setPhotoName: (name, uid) => {
+    try {
+      fetch
+        .updateUserData(uid, { photoName: name })
+        .then(() => {
+        // TODO: if nothing went bad, keep the display name,
+        // otherwise, change it back (or dont, depends how we wanna do it)
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    } catch (err) {
+      console.error(err);
+    }
+    dispatch(setPhotoName(name));
+  },
   togglePanel: () => {
     dispatch(togglePanel());
   },

--- a/src/components/common/containers/ProfilePanelContainer.js
+++ b/src/components/common/containers/ProfilePanelContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { togglePanel } from '../../../actions/uiActions';
-import { setDisplayName, setPhotoName } from '../../../actions/userDataActions';
+import { setDisplayName, setPhotoName, setError } from '../../../actions/userDataActions';
 import { DEFAULT_PHOTO_NAME, CLOSED_PANEL_LEFT, OPEN_PANEL_LEFT } from '../../../constants';
 import ProfilePanel from '../ProfilePanel';
 
@@ -19,6 +19,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   collectUserPhoto: () => {},
   setDisplayName: (name) => dispatch(setDisplayName(name)),
   setPhotoName: (name) => dispatch(setPhotoName(name)),
+  setUserDataError: (errorMsg) => dispatch(setError(errorMsg)),
   togglePanel: () => {
     dispatch(togglePanel());
   },

--- a/src/reducers/userDataReducer.js
+++ b/src/reducers/userDataReducer.js
@@ -19,25 +19,23 @@ const initialState = {
 
 function userDataReducer(state = initialState, action) {
   switch (action.type) {
-  case LOAD_USER_DATA:
-    // pull all values we want to pay attention to out of the object
-    return { ...state, ...action.userData };
-  case CLEAR_USER_DATA:
-    return initialState;
-  case LOAD_FAILURE:
-    return { ...state, error: action.message };
-  case SET_DISPLAY_NAME: {
-    return { ...state, displayName: action.value };
-  }
-  case SET_PHOTO_NAME: {
-    return { ...state, photoName: action.photoName };
-  }
-  case SET_MOST_RECENT_PROGRAM:
-    return { ...state, mostRecentProgram: action.value };
-  case SET_CURRENT_CLASS:
-    return { ...state, currentClass: action.value };
-  default:
-    return state;
+    case LOAD_USER_DATA:
+      // pull all values we want to pay attention to out of the object
+      return { ...state, ...action.userData };
+    case CLEAR_USER_DATA:
+      return initialState;
+    case LOAD_FAILURE:
+      return { ...state, error: action.message };
+    case SET_DISPLAY_NAME:
+      return { ...state, displayName: action.value };
+    case SET_PHOTO_NAME:
+      return { ...state, photoName: action.photoName };
+    case SET_MOST_RECENT_PROGRAM:
+      return { ...state, mostRecentProgram: action.value };
+    case SET_CURRENT_CLASS:
+      return { ...state, currentClass: action.value };
+    default:
+      return state;
   }
 }
 export default userDataReducer;

--- a/src/reducers/userDataReducer.js
+++ b/src/reducers/userDataReducer.js
@@ -17,6 +17,7 @@ const initialState = {
   currentClass: '',
 };
 
+// eslint-disable-next-line default-param-last
 function userDataReducer(state = initialState, action) {
   switch (action.type) {
   case LOAD_USER_DATA:

--- a/src/reducers/userDataReducer.js
+++ b/src/reducers/userDataReducer.js
@@ -19,23 +19,23 @@ const initialState = {
 
 function userDataReducer(state = initialState, action) {
   switch (action.type) {
-    case LOAD_USER_DATA:
-      // pull all values we want to pay attention to out of the object
-      return { ...state, ...action.userData };
-    case CLEAR_USER_DATA:
-      return initialState;
-    case LOAD_FAILURE:
-      return { ...state, error: action.message };
-    case SET_DISPLAY_NAME:
-      return { ...state, displayName: action.value };
-    case SET_PHOTO_NAME:
-      return { ...state, photoName: action.photoName };
-    case SET_MOST_RECENT_PROGRAM:
-      return { ...state, mostRecentProgram: action.value };
-    case SET_CURRENT_CLASS:
-      return { ...state, currentClass: action.value };
-    default:
-      return state;
+  case LOAD_USER_DATA:
+    // pull all values we want to pay attention to out of the object
+    return { ...state, ...action.userData };
+  case CLEAR_USER_DATA:
+    return initialState;
+  case LOAD_FAILURE:
+    return { ...state, error: action.message };
+  case SET_DISPLAY_NAME:
+    return { ...state, displayName: action.value };
+  case SET_PHOTO_NAME:
+    return { ...state, photoName: action.photoName };
+  case SET_MOST_RECENT_PROGRAM:
+    return { ...state, mostRecentProgram: action.value };
+  case SET_CURRENT_CLASS:
+    return { ...state, currentClass: action.value };
+  default:
+    return state;
   }
 }
 export default userDataReducer;

--- a/src/reducers/userDataReducer.js
+++ b/src/reducers/userDataReducer.js
@@ -33,18 +33,7 @@ function userDataReducer(state = initialState, action) {
     return { ...state, displayName: action.value };
   }
   case SET_PHOTO_NAME: {
-    const newPhotoName = action.photoName;
-    fetch
-      .updateUserData(state.uid, { photoName: newPhotoName })
-      .then(() => {
-        // TODO: if nothing went bad, keep the display name,
-        // otherwise, change it back (or dont, depends how we wanna do it)
-      })
-      .catch((err) => {
-        state.error = err;
-        console.log(err);
-      });
-    return { ...state, photoName: newPhotoName };
+    return { ...state, photoName: action.photoName };
   }
   case SET_MOST_RECENT_PROGRAM:
     fetch

--- a/src/reducers/userDataReducer.js
+++ b/src/reducers/userDataReducer.js
@@ -38,7 +38,7 @@ function userDataReducer(state = initialState, action) {
   case SET_CURRENT_CLASS:
     return { ...state, currentClass: action.value };
   case SET_ERROR:
-    return { ...state, error: action.value }
+    return { ...state, error: action.value };
   default:
     return state;
   }

--- a/src/reducers/userDataReducer.js
+++ b/src/reducers/userDataReducer.js
@@ -6,6 +6,7 @@ import {
   SET_MOST_RECENT_PROGRAM,
   SET_PHOTO_NAME,
   SET_CURRENT_CLASS,
+  SET_ERROR,
 } from '../actions/userDataActions';
 
 import * as fetch from '../lib/fetch.js';
@@ -62,6 +63,8 @@ function userDataReducer(state = initialState, action) {
     return { ...state, mostRecentProgram: action.value };
   case SET_CURRENT_CLASS:
     return { ...state, currentClass: action.value };
+  case SET_ERROR:
+    return { ...state, error: action.value }
   default:
     return state;
   }

--- a/src/reducers/userDataReducer.js
+++ b/src/reducers/userDataReducer.js
@@ -36,12 +36,6 @@ function userDataReducer(state = initialState, action) {
     return { ...state, photoName: action.photoName };
   }
   case SET_MOST_RECENT_PROGRAM:
-    fetch
-      .updateUserData(state.uid, { mostRecentProgram: action.value })
-      .catch((err) => {
-        state.error = err;
-        console.log(err);
-      });
     return { ...state, mostRecentProgram: action.value };
   case SET_CURRENT_CLASS:
     return { ...state, currentClass: action.value };

--- a/src/reducers/userDataReducer.js
+++ b/src/reducers/userDataReducer.js
@@ -6,7 +6,6 @@ import {
   SET_MOST_RECENT_PROGRAM,
   SET_PHOTO_NAME,
   SET_CURRENT_CLASS,
-  SET_ERROR,
 } from '../actions/userDataActions';
 
 const initialState = {
@@ -37,8 +36,6 @@ function userDataReducer(state = initialState, action) {
     return { ...state, mostRecentProgram: action.value };
   case SET_CURRENT_CLASS:
     return { ...state, currentClass: action.value };
-  case SET_ERROR:
-    return { ...state, error: action.value };
   default:
     return state;
   }

--- a/src/reducers/userDataReducer.js
+++ b/src/reducers/userDataReducer.js
@@ -30,14 +30,7 @@ function userDataReducer(state = initialState, action) {
   case LOAD_FAILURE:
     return { ...state, error: action.message };
   case SET_DISPLAY_NAME: {
-    const newName = action.value;
-    fetch
-      .updateUserData(state.uid, { displayName: newName })
-      .catch((err) => {
-        state.error = err;
-        console.log(err);
-      });
-    return { ...state, displayName: newName };
+    return { ...state, displayName: action.value };
   }
   case SET_PHOTO_NAME: {
     const newPhotoName = action.photoName;

--- a/src/reducers/userDataReducer.js
+++ b/src/reducers/userDataReducer.js
@@ -9,8 +9,6 @@ import {
   SET_ERROR,
 } from '../actions/userDataActions';
 
-import * as fetch from '../lib/fetch.js';
-
 const initialState = {
   error: '',
   displayName: '',


### PR DESCRIPTION
Fixes #635.

Fetch calls are moved out of userDataReducer. The rest of the logic (error handling, in particular) remains untouched.

The reason I kept the original logic is that I think it may not be a good idea for me to make too many assumptions about the desired behavior, before any additional discussion/confirmation. In addition, I also saw that there's error-handling logic that depends on the previous implementation in other places. 

That said, we can definitely further discuss any related refactorings in this PR, or we can open a new issue for this.