### PR TITLE
Fix crash on non-ASCII Python output

### DIFF
--- a/src/util/languages/JsSourceDocLoggingScript.js
+++ b/src/util/languages/JsSourceDocLoggingScript.js
@@ -1,0 +1,38 @@
+export default function getJsSrcDocLoggingScript() {
+  return `
+<script type="text/javascript">
+  if (typeof console  != "undefined")
+    if (typeof console.log != 'undefined')
+      console.olog = console.log;
+    else
+      console.olog = function() {};
+
+  console.log = (message) => {
+    console.olog(message);
+    let a = document.getElementById("inner")
+    if(a){
+      // a.style.display = "block"
+      a.value = a.value + "> " + message + "\\n";
+      if(a.scrollTop >= (a.scrollHeight - a.offsetHeight) - a.offsetHeight){
+        a.scrollTop = a.scrollHeight
+      }
+    }
+  };
+
+  window.onerror = (err)=> {
+    let a = document.getElementById("outer")
+    if(a){
+      a.style.display = "block"
+    }
+    console.log("\\n\\nERROR: " + err + "\\n")
+  }
+
+  console.error = console.debug = console.info = console.log;
+
+  function closeConsole(){
+    var mypre = document.getElementById("inner");
+    mypre.style.display = "none"
+  }
+</script>
+`;
+}

--- a/src/util/languages/Processing.js
+++ b/src/util/languages/Processing.js
@@ -1,4 +1,4 @@
-import { getJsSrcDocLoggingScript } from './languages.js';
+import getJsSrcDocLoggingScript from './JsSourceDocLoggingScript';
 
 const getUserScript = (code) => `
   <script type="text/javascript">

--- a/src/util/languages/Processing.js
+++ b/src/util/languages/Processing.js
@@ -46,6 +46,6 @@ const getProcessingSrcDocHead = () => `
     </head>
   `;
 
-export default function (code, showConsole) {
+export default function CreateProcessingDoc(code, showConsole) {
   return `<html> ${getProcessingSrcDocHead()} ${getProcessingSrcDocBody(code, showConsole)}</html>`;
 }

--- a/src/util/languages/Python.js
+++ b/src/util/languages/Python.js
@@ -1,8 +1,6 @@
 import Sk from 'skulpt';
 
-export default function (code) {
-  const prog = atob(code);
-
+export default function CreatePythonDoc(prog) {
   function outf(text) {
     const mypre = document.getElementById('inner');
     let received;

--- a/src/util/languages/React.js
+++ b/src/util/languages/React.js
@@ -58,6 +58,6 @@ const getReactSrcDocBody = (code, showConsole) => `
     </body>
   `;
 
-export default function (code, showConsole) {
+export default function CreateReactDoc(code, showConsole) {
   return `<html> ${getReactSrcDocHead()} ${getReactSrcDocBody(code, showConsole)}</html>`;
 }

--- a/src/util/languages/React.js
+++ b/src/util/languages/React.js
@@ -1,4 +1,4 @@
-import { getJsSrcDocLoggingScript } from './languages.js';
+import getJsSrcDocLoggingScript from './JsSourceDocLoggingScript';
 
 const getReactSrcDocHead = () => `
     <head>

--- a/src/util/languages/languages.js
+++ b/src/util/languages/languages.js
@@ -11,7 +11,7 @@ export const SUPPORTED_LANGUAGES = [
     icon: faPython,
     codemirror: 'python',
     extension: 'py',
-    render: (code, showConsole) => CreatePythonDoc(btoa(code), showConsole),
+    render: CreatePythonDoc,
   },
   //   {
   //     value: "javascript",
@@ -65,40 +65,3 @@ export const enrichWithLanguageData = (arr) => arr.map((sketch) => ({
   ...sketch,
   language: getLanguageData(sketch.language),
 }));
-
-export const getJsSrcDocLoggingScript = () => `
-<script type="text/javascript">
-  if (typeof console  != "undefined")
-    if (typeof console.log != 'undefined')
-      console.olog = console.log;
-    else
-      console.olog = function() {};
-
-  console.log = (message) => {
-    console.olog(message);
-    let a = document.getElementById("inner")
-    if(a){
-      // a.style.display = "block"
-      a.value = a.value + "> " + message + "\\n";
-      if(a.scrollTop >= (a.scrollHeight - a.offsetHeight) - a.offsetHeight){
-        a.scrollTop = a.scrollHeight
-      }
-    }
-  };
-
-  window.onerror = (err)=> {
-    let a = document.getElementById("outer")
-    if(a){
-      a.style.display = "block"
-    }
-    console.log("\\n\\nERROR: " + err + "\\n")
-  }
-
-  console.error = console.debug = console.info = console.log;
-
-  function closeConsole(){
-    var mypre = document.getElementById("inner");
-    mypre.style.display = "none"
-  }
-</script>
-`;


### PR DESCRIPTION
Fixes #521 (Unicode support) and a circular import issue caught by lints. Python programs can now safely output Unicode.
![image](https://user-images.githubusercontent.com/28466971/232962171-7a484766-a019-4937-ab0c-43a1522c78ab.png)
