### PR TITLE
Changed matching bracket highlight color

### DIFF
--- a/src/styles/CustomCM.scss
+++ b/src/styles/CustomCM.scss
@@ -141,6 +141,16 @@ span.cm-variable {
   overflow: hidden !important;
 }
 
+/* highlights matching bracket when user clicks on one of the brackets */
+.CodeMirror-matchingbracket {
+  text-decoration: none;
+
+  @include themify($themes) {
+    background-color: themed("highlightBracket");
+    color: themed('color');
+  }
+}
+
 /* most of the codemirror styles we can override for text
 .cm-s-material .CodeMirror-activeline-background { background: rgba(0, 0, 0, 0); }
 .cm-s-material .cm-operator { color: rgba(233, 237, 237, 1); }

--- a/src/styles/Editor.scss
+++ b/src/styles/Editor.scss
@@ -132,10 +132,7 @@
     background-color: themed("backgroundColor");
   }
 
-  .cm-s-material .CodeMirror-matchingbracket {
-    background-color: rgb(0 255 0 / 40%);
-    text-decoration: none;
-  }
+  
 }
 
 .btn-language-dropdown {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -72,6 +72,7 @@ $themes: (
     property: #056d45,
     cursor: #f4ee94,
     selectedLine: $off-white,
+    highlightBracket: rgba(174, 214, 67, 0.4), //$teachla-green but with lower opacity
   ),
   dark: (
     // defaults
@@ -96,6 +97,7 @@ $themes: (
     property: #80cbae,
     cursor: #f4ee94,
     selectedLine: rgba(255, 255, 255, 0.1),
+    highlightBracket: rgba(40, 170, 38, 0.4), //$teachla-secondary-2 but with lower opacity
   ),
 );
 


### PR DESCRIPTION
Resolves issue #1028. Changes the color so more visible on light mode. 

On light mode, change the bracket color from white to black and the bracket highlight from white to green. On dark mode, changed bracket highlight to another shade of green.

Light Mode:
<img width="262" alt="Screenshot 2023-05-09 at 5 50 23 PM" src="https://github.com/uclaacm/TeachLAFrontend/assets/124432604/d417af65-ed09-4137-b909-c2925443edbe">

Dark Mode:
<img width="258" alt="Screenshot 2023-05-09 at 5 50 44 PM" src="https://github.com/uclaacm/TeachLAFrontend/assets/124432604/44a414e8-8487-4655-84d7-95d4ae57d54d">
