### PR TITLE
Encode current program into URL as `/editor/:programid`, push to browser history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "cross-env": "^7.0.3",
         "crypto-js": "^4.1.1",
         "firebase": "^9.12.1",
+        "history": "^4.9.0",
         "immutable": "^4.0.0",
         "react": "^16.14.0",
         "react-codemirror2": "^7.2.1",
@@ -30,6 +31,7 @@
         "react-split-pane": "^0.1.92",
         "reactstrap": "^9.0.1",
         "redux": "^4.1.2",
+        "redux-thunk": "^2.4.2",
         "skulpt": "^1.2.0"
       },
       "devDependencies": {
@@ -18994,6 +18996,14 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
@@ -25333,12 +25343,14 @@
     "@firebase/auth-interop-types": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
-      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g=="
+      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
+      "requires": {}
     },
     "@firebase/auth-types": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.11.0.tgz",
-      "integrity": "sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw=="
+      "integrity": "sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==",
+      "requires": {}
     },
     "@firebase/component": {
       "version": "0.5.20",
@@ -25414,7 +25426,8 @@
     "@firebase/firestore-types": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.5.0.tgz",
-      "integrity": "sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA=="
+      "integrity": "sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA==",
+      "requires": {}
     },
     "@firebase/functions": {
       "version": "0.8.7",
@@ -25473,7 +25486,8 @@
     "@firebase/installations-types": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.4.0.tgz",
-      "integrity": "sha512-nXxWKQDvBGctuvsizbUEJKfxXU9WAaDhon+j0jpjIfOJkvkj3YHqlLB/HeYjpUn85Pb22BjplpTnDn4Gm9pc3A=="
+      "integrity": "sha512-nXxWKQDvBGctuvsizbUEJKfxXU9WAaDhon+j0jpjIfOJkvkj3YHqlLB/HeYjpUn85Pb22BjplpTnDn4Gm9pc3A==",
+      "requires": {}
     },
     "@firebase/logger": {
       "version": "0.3.3",
@@ -25598,7 +25612,8 @@
     "@firebase/storage-types": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.6.0.tgz",
-      "integrity": "sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA=="
+      "integrity": "sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA==",
+      "requires": {}
     },
     "@firebase/util": {
       "version": "1.7.2",
@@ -30607,7 +30622,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-react-app": {
       "version": "6.0.0",
@@ -30955,7 +30971,8 @@
     "eslint-plugin-react-hooks": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
-      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw=="
+      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "3.10.2",
@@ -39368,6 +39385,12 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "requires": {}
+    },
     "reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
@@ -41122,7 +41145,8 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
           "integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cross-env": "^7.0.3",
     "crypto-js": "^4.1.1",
     "firebase": "^9.12.1",
+    "history": "^4.9.0",
     "immutable": "^4.0.0",
     "react": "^16.14.0",
     "react-codemirror2": "^7.2.1",
@@ -26,6 +27,7 @@
     "react-split-pane": "^0.1.92",
     "reactstrap": "^9.0.1",
     "redux": "^4.1.2",
+    "redux-thunk": "^2.4.2",
     "skulpt": "^1.2.0"
   },
   "scripts": {

--- a/src/actions/userDataActions.js
+++ b/src/actions/userDataActions.js
@@ -1,3 +1,5 @@
+import history from '../history';
+
 export const LOAD_USER_DATA = 'LOAD_USER_DATA';
 export function loadUserData(uid, userData) {
   // add uid to the userData object
@@ -51,7 +53,15 @@ export function programUploadFailure(error) {
 
 export const SET_MOST_RECENT_PROGRAM = 'SET_MOST_RECENT_PROGRAM';
 export function setMostRecentProgram(program) {
-  return { type: SET_MOST_RECENT_PROGRAM, value: program };
+  return (dispatch, getState) => {
+    if (getState().userData.mostRecentProgram !== program) {
+      // push to history if the URL isn't already on the right program
+      if (window.location.pathname !== `/editor/${program}`) {
+        history.push(`/editor/${program}`);
+      }
+      dispatch({ type: SET_MOST_RECENT_PROGRAM, value: program });
+    }
+  };
 }
 
 export const SET_PHOTO_NAME = 'SET_PHOTO_NAME';

--- a/src/components/Class/components/ClassSketchList.js
+++ b/src/components/Class/components/ClassSketchList.js
@@ -11,11 +11,8 @@ import '../../../styles/SketchBox.scss';
 const SKETCHES_ROW_PADDING = 100;
 const SKETCH_WIDTH = 220;
 
-const ClassSketchList = function ({
-  calculatedWidth,
-  isInstr,
-  programData,
-  setCreateSketchModalOpen,
+function ClassSketchList({
+  calculatedWidth, isInstr, programData, setCreateSketchModalOpen,
 }) {
   const newList = programData?.concat([]) || [];
   newList.sort((a, b) => {
@@ -42,7 +39,7 @@ const ClassSketchList = function ({
       downloadFunc={() => {
         CodeDownloader.download(name, language, code);
       }}
-      pathname={isInstr ? '/editor' : `/p/${uid}`}
+      pathname={isInstr ? `/editor/${uid}` : `/p/${uid}`}
     />
   ));
 
@@ -78,6 +75,6 @@ const ClassSketchList = function ({
   }
   if (rows.length === 0) return 'No sketches found';
   return <div className="class-sketches-grid">{rows}</div>;
-};
+}
 
 export default ClassSketchList;

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { Redirect } from 'react-router-dom';
 
+import { setMostRecentProgram } from '../actions/userDataActions';
 import { EDITOR_WIDTH_BREAKPOINT, CODE_AND_OUTPUT, CODE_ONLY } from '../constants';
 import * as cookies from '../lib/cookies';
 import * as fetch from '../lib/fetch';
+import store from '../store';
 import ClassPageContainer from './Class/containers/ClassPageContainer';
 import ClassesPageContainer from './Classes/containers/ClassesContainer';
 import ProfilePanelContainer from './common/containers/ProfilePanelContainer';
@@ -18,7 +20,7 @@ import '../styles/Main.scss';
  * left: the left css property that should be applied on the top level element
  */
 
-const Main = function ({
+function Main({
   screenWidth,
   theme,
   dirty,
@@ -41,6 +43,13 @@ const Main = function ({
     screenWidth <= EDITOR_WIDTH_BREAKPOINT ? CODE_ONLY : CODE_AND_OUTPUT,
   );
   const [pane1Style, setPane1Style] = useState({ transition: 'width .5s ease' });
+
+  // Keep mostRecentProgram consistent with programid in the URL
+  useEffect(() => {
+    if (programid !== undefined) {
+      store.dispatch(setMostRecentProgram(programid));
+    }
+  }, [programid]);
 
   // Set theme from cookies (yum)
   useEffect(() => {
@@ -147,5 +156,5 @@ const Main = function ({
       </div>
     </div>
   );
-};
+}
 export default Main;

--- a/src/components/Sketches/components/ConfirmDeleteModal.js
+++ b/src/components/Sketches/components/ConfirmDeleteModal.js
@@ -49,9 +49,9 @@ const ConfirmDeleteModal = (props) => {
           // then we need to re-populate it with something different.
           if (programKeys.size > 0 && sketchKey === mostRecentProgram) {
             if (sketchKey === programKeys.get(0)) {
-              setMostRecentProgram(programKeys.get(1), uid);
+              setMostRecentProgram(programKeys.get(1));
             } else {
-              setMostRecentProgram(programKeys.get(0), uid);
+              setMostRecentProgram(programKeys.get(0));
             }
           }
 

--- a/src/components/Sketches/components/CreateSketchModal.js
+++ b/src/components/Sketches/components/CreateSketchModal.js
@@ -128,7 +128,7 @@ const CreateSketchModal = (props) => {
         .then((json) => {
           const { uid: uidresponse, ...programData } = json;
           addProgram(uidresponse, programData || {});
-          setMostRecentProgram(uidresponse, uid);
+          setMostRecentProgram(uidresponse);
           setRedirect(true);
           closeModal();
         })

--- a/src/components/Sketches/index.js
+++ b/src/components/Sketches/index.js
@@ -48,12 +48,6 @@ class Sketches extends React.Component {
     });
   };
 
-  setProgram = (name) => {
-    const { uid, setMostRecentProgram } = this.props;
-
-    setMostRecentProgram(name, uid);
-  };
-
   renderHeader = () => (
     <div className="sketches-header">
       <OpenPanelButtonContainer />
@@ -128,9 +122,7 @@ class Sketches extends React.Component {
               key,
             );
           }}
-          redirFunc={() => {
-            this.setProgram(key);
-          }}
+          pathname={`/editor/${key}`}
         />,
       );
     });

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import {
-  BrowserRouter as Router, Route, Redirect, Switch,
+  Router, Route, Redirect, Switch,
 } from 'react-router-dom';
 
 import { ROUTER_BASE_NAME } from '../constants';
 import { onAuthStateChanged } from '../firebase';
+import history from '../history';
+import store from '../store';
 import LoadingPage from './common/LoadingPage';
 import LoginPage from './containers/LoginContainer';
 import MainContainer from './containers/MainContainer';
@@ -90,10 +92,10 @@ class App extends React.Component {
     const isValidUser = uid;
 
     return (
-      <Router basename={ROUTER_BASE_NAME}>
+      <Router basename={ROUTER_BASE_NAME} history={history}>
         <div className="app">
           <Switch>
-            {/* if the user is loggedIn, redirect them to the editor, otherwise, show the login page*? */}
+            {/* if the user is loggedIn, redirect them to the editor, otherwise, show the login page */}
             <Route
               exact
               path="/"
@@ -107,7 +109,7 @@ class App extends React.Component {
                 return <LoginPage />;
               }}
             />
-            {/* if the user is loggedIn, redirect them to the editor, otherwise, show the login page*? */}
+            {/* if the user is loggedIn, redirect them to the editor, otherwise, show the login page */}
             <Route
               path="/login"
               render={() => {
@@ -120,20 +122,23 @@ class App extends React.Component {
                 return <LoginPage />;
               }}
             />
-            {/* if the user is not loggedIn, redirect them to the login page, otherwise, show the editor page*? */}
+            {/* if the user is not loggedIn, redirect them to the login page, otherwise, show the editor page */}
             <Route
-              path="/editor"
-              render={() => {
+              path="/editor/:programid?"
+              render={({ match }) => {
                 if (errorMsg !== '') {
                   return <Error errorMsg={errorMsg} isValidUser={isValidUser} />;
                 }
                 if (!isValidUser) {
                   return <Redirect to="/login" />;
                 }
-                return <MainContainer contentType="editor" />;
+                if (!match.params.programid) {
+                  return <Redirect to={`/editor/${store.getState().userData.mostRecentProgram}`} />;
+                }
+                return <MainContainer contentType="editor" programid={match.params.programid} />;
               }}
             />
-            {/* if the user is loggedIn, redirect them to the editor page, otherwise, show the createUser page*? */}
+            {/* if the user is loggedIn, redirect them to the editor page, otherwise, show the createUser page */}
             <Route
               path="/createUser"
               render={({ location }) => {
@@ -146,7 +151,7 @@ class App extends React.Component {
                 return <LoginPage create initialState={location.state} />;
               }}
             />
-            {/* if the user isn't loggedIn, redirect them to the login page, otherwise, show the view page*? */}
+            {/* if the user isn't loggedIn, redirect them to the login page, otherwise, show the view page */}
             <Route
               path="/sketches"
               render={() => {
@@ -162,8 +167,8 @@ class App extends React.Component {
             {/* Get program endpoint */}
             <Route
               path="/p/:programid"
-              render={(props) => (
-                <ViewOnlyContainer contentType="view" programid={props.match.params.programid} />
+              render={({ match }) => (
+                <ViewOnlyContainer contentType="view" programid={match.params.programid} />
               )}
             />
             {/* Class page */}

--- a/src/history.js
+++ b/src/history.js
@@ -1,0 +1,3 @@
+import { createBrowserHistory } from 'history';
+
+export default createBrowserHistory();

--- a/src/index.js
+++ b/src/index.js
@@ -4,15 +4,9 @@ import ReactDOM from 'react-dom';
 import 'bootstrap/dist/css/bootstrap.css';
 import './styles/global.scss';
 import { Provider } from 'react-redux';
-import { createStore } from 'redux';
 import Root from './components/containers/AppContainer';
-import appReducers from './reducers';
 import registerServiceWorker from './registerServiceWorker';
-
-const store = createStore(
-  appReducers,
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
-);
+import store from './store';
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,8 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import appReducers from './reducers';
+
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const store = createStore(appReducers, composeEnhancers(applyMiddleware(thunkMiddleware)));
+
+export default store;


### PR DESCRIPTION
Closes #746 
This makes the URL reflect the current program, which used to live only in `mostRecentProgram` in the Redux state. On page load, the URL acts as a source of truth to set `mostRecentProgram`. After that point, we want Redux to be the source of truth so the URL will change whenever `mostRecentProgram` is set. This conveniently leaves the existing calls to `setMostRecentProgram` untouched.

This is also integrated with browser history so switching between files will let the forward/back buttons work as you expect.