### PR TITLE
Update sketch deletion to avoid setMostRecentProgram

### DIFF
--- a/src/components/Sketches/components/ConfirmDeleteModal.js
+++ b/src/components/Sketches/components/ConfirmDeleteModal.js
@@ -7,15 +7,7 @@ import * as fetch from '../../../lib/fetch';
 
 const ConfirmDeleteModal = (props) => {
   const {
-    onClose,
-    isOpen,
-    sketchName,
-    uid,
-    sketchKey,
-    deleteProgram,
-    mostRecentProgram,
-    programKeys,
-    setMostRecentProgram,
+    onClose, isOpen, sketchName, uid, sketchKey, deleteProgram,
   } = props;
 
   const [_spinner, setSpinner] = useState(true);
@@ -37,25 +29,13 @@ const ConfirmDeleteModal = (props) => {
       fetch
         .deleteSketch(data)
         .then((res) => {
-          if (!res.ok) {
+          if (res.ok) {
+            deleteProgram(sketchKey);
+            closeModal();
+          } else {
             setSpinner(false);
             setError(res.text() || 'Failed to delete sketch, please try again later');
-            return;
           }
-
-          deleteProgram(sketchKey);
-
-          // this next piece of code is a guard against deleting mostRecentProgram - if we do,
-          // then we need to re-populate it with something different.
-          if (programKeys.size > 0 && sketchKey === mostRecentProgram) {
-            if (sketchKey === programKeys.get(0)) {
-              setMostRecentProgram(programKeys.get(1));
-            } else {
-              setMostRecentProgram(programKeys.get(0));
-            }
-          }
-
-          closeModal();
         })
         .catch((err) => {
           setSpinner(false);

--- a/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
+++ b/src/components/Sketches/containers/ConfirmDeleteModalContainer.js
@@ -1,31 +1,11 @@
 import { connect } from 'react-redux';
 import { deleteProgram } from '../../../actions/programsActions';
-import { setMostRecentProgram } from '../../../actions/userDataActions';
-import * as fetch from '../../../lib/fetch';
 import ConfirmDeleteModal from '../components/ConfirmDeleteModal';
 
-const mapStateToProps = (state) => {
-  const { mostRecentProgram, uid } = state.userData;
-  const programKeys = state.programs.keySeq(); // this is an immutable sequence
-  return {
-    mostRecentProgram,
-    programKeys,
-    uid,
-  };
-};
+const mapStateToProps = (state) => ({ uid: state.userData.uid });
 
 const mapDispatchToProps = (dispatch) => ({
   deleteProgram: (program, data) => dispatch(deleteProgram(program, data)),
-  setMostRecentProgram: (value, uid) => {
-    try {
-      fetch.updateUserData(uid, { mostRecentProgram: value }).catch((err) => {
-        console.error(err);
-      });
-    } catch (err) {
-      console.error(err);
-    }
-    dispatch(setMostRecentProgram(value));
-  },
 });
 
 const ConfirmDeleteModalContainer = connect(

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -133,7 +133,19 @@ class App extends React.Component {
                   return <Redirect to="/login" />;
                 }
                 if (!match.params.programid) {
-                  return <Redirect to={`/editor/${store.getState().userData.mostRecentProgram}`} />;
+                  const lastMostRecentProgram = store.getState().userData.mostRecentProgram;
+                  const programKeys = store.getState().programs.keySeq();
+                  if (programKeys.includes(lastMostRecentProgram)) {
+                    return <Redirect to={`/editor/${lastMostRecentProgram}`} />;
+                  }
+                  // mostRecentProgram no longer exists, fall back to one of the
+                  // programs that does exist
+                  if (programKeys.get(0)) {
+                    return <Redirect to={`/editor/${programKeys.get(0)}`} />;
+                  }
+                  // No programs exist, redirect to /sketches so the user can make one
+
+                  return <Redirect to="/sketches" />;
                 }
                 return <MainContainer contentType="editor" programid={match.params.programid} />;
               }}


### PR DESCRIPTION
With the changes for #746, `setMostRecentProgram` will update the URL to `/editor/:newMostRecentProgram` but this is undesirable from the sketches page.
Remove the `mostRecentProgram` accounting from the sketch deletion modal and do that work in the /editor path of the router.
This is also more resilient to other ways that `mostRecentProgram` could get corrupted, besides sketch deletion.